### PR TITLE
fix type Service.Target.Entity

### DIFF
--- a/types.go
+++ b/types.go
@@ -60,9 +60,7 @@ type Service struct {
 	Description string                  `json:"description"`
 	Fields      map[string]ServiceField `json:"fields"`
 	Target      struct {
-		Entity struct {
-			Domain string `json:"domain"`
-		} `json:"entity"`
+		Entity []map[string]interface{} `json:"entity"`
 	} `json:"target"`
 }
 


### PR DESCRIPTION
home assistant returns empty struct, or more fields; this change resolves decoding of Entity
this commit refers to issue https://github.com/mkelcik/go-ha-client/issues/4