### PR TITLE
chore: bump Go toolchain and CI to 1.25.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.8"
           cache: true
       - run: make tools
       - run: make ci
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.8"
           cache: true
       - run: |
           cp go.mod /tmp/go.mod
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.8"
           cache: true
       - run: go test -race ./...
 
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.8"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./...
       - uses: actions/upload-artifact@v4
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.8"
           cache: true
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: "$(go env GOPATH)/bin/govulncheck ./..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+### Changed
+- Bump minimum Go version, toolchain, and CI from `1.24.13` to `1.25.8`.
+
+### Fixed
+- Address standard library vulnerability findings from `govulncheck` by running on Go `1.25.8` (fixes include GO-2026-4601 and GO-2026-4602).
+
 ## [v2.0.0-beta.19]
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for contributing to `go-ha-client`!
 ## Development setup
 
 Requirements:
-- Go `1.24.13+`
+- Go `1.25.8+`
 - Make
 
 Clone and run checks:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://developers.home-assistant.io/docs/api/websocket
 The client follows official Home Assistant REST and WebSocket API docs.
 
 ### Requirements
-- Go `1.24.13+`
+- Go `1.25.8+`
 - Home Assistant with long-lived access token
 
 ### Get a Home Assistant token
@@ -35,7 +35,7 @@ The client follows official Home Assistant REST and WebSocket API docs.
 - `v2.x` releases may add new helpers/options and bug fixes, but will not introduce intentional breaking API changes.
 - Breaking API changes will be introduced only in a new major version (for example `v3`).
 - The package targets official Home Assistant REST and WebSocket APIs and follows their documented behavior where possible.
-- Minimum supported Go version is `1.24.13+` (see CI/tooling in this repository).
+- Minimum supported Go version is `1.25.8+` (see CI/tooling in this repository).
 - Security issues should be reported using the process in [`SECURITY.md`](SECURITY.md).
 
 ### Non-goals

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/mkelcik/go-ha-client/v2
 
-go 1.24
+go 1.25
 
-toolchain go1.24.13
+toolchain go1.25.8
 
 require github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## What changed

update Go toolchain and CI to 1.25.8

## Why

`=== Symbol Results ===

Vulnerability #1: GO-2026-4602
    FileInfo can escape from a Root in os
  More info: https://pkg.go.dev/vuln/GO-2026-4602
  Standard library
    Found in: os@go1.24.13
    Fixed in: os@go1.25.8
    Example traces found:
Error:       #1: client.go:160:33: ha.cloneHTTPTransport calls http.Transport.Clone, which eventually calls os.ReadDir

Vulnerability #2: GO-2026-4601
    Incorrect parsing of IPv6 host literals in net/url
  More info: https://pkg.go.dev/vuln/GO-2026-4601
  Standard library
    Found in: net/url@go1.24.13
    Fixed in: net/url@go1.25.8
    Example traces found:
Error:       #1: client.go:613:40: ha.Client.doWithHeaders calls http.NewRequestWithContext, which calls url.Parse
Error:       #2: client.go:121:34: ha.NewClient calls url.ParseRequestURI
Error:       #3: client.go:624:30: ha.Client.doWithHeaders calls http.Client.Do, which eventually calls url.URL.Parse

Your code is affected by 2 vulnerabilities from the Go standard library.
This scan also found 0 vulnerabilities in packages you import and 1
vulnerability in modules you require, but your code doesn't appear to call these
vulnerabilities.
Use '-show verbose' for more details.`

## Checklist

- [x] I ran `make ci` locally.
- [x] I added/updated tests for behavior changes.
- [x] I updated `README.md` for public API changes.
- [x] I updated `CHANGELOG.md` (if user-visible).
