### PR TITLE
bump Go toolchain to 1.25.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.8"
+          go-version: "1.25.9"
           cache: true
       - run: make tools
       - run: make ci
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.8"
+          go-version: "1.25.9"
           cache: true
       - run: |
           cp go.mod /tmp/go.mod
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.8"
+          go-version: "1.25.9"
           cache: true
       - run: go test -race ./...
 
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.8"
+          go-version: "1.25.9"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./...
       - uses: actions/upload-artifact@v4
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.8"
+          go-version: "1.25.9"
           cache: true
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: "$(go env GOPATH)/bin/govulncheck ./..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
-## [v2.1.0]
+## [v2.1.1]
 
 ### Changed
-- Bump minimum Go version, toolchain, and CI from `1.24.13` to `1.25.8`.
+- Bump minimum Go version, toolchain, and CI from `1.25.8` to `1.25.9`.
 
 ### Fixed
-- Address standard library vulnerability findings from `govulncheck` by running on Go `1.25.8` (fixes include GO-2026-4601 and GO-2026-4602).
+- Address remaining standard library vulnerability findings from `govulncheck` by running on Go `1.25.9` (fixes include GO-2026-4946, GO-2026-4947, and GO-2026-4870).
+
+## [v2.1.0]
 
 ### Changed
 - Bump minimum Go version, toolchain, and CI from `1.24.13` to `1.25.8`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for contributing to `go-ha-client`!
 ## Development setup
 
 Requirements:
-- Go `1.25.8+`
+- Go `1.25.9+`
 - Make
 
 Clone and run checks:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://developers.home-assistant.io/docs/api/websocket
 The client follows official Home Assistant REST and WebSocket API docs.
 
 ### Requirements
-- Go `1.25.8+`
+- Go `1.25.9+`
 - Home Assistant with long-lived access token
 
 ### Get a Home Assistant token
@@ -35,7 +35,7 @@ The client follows official Home Assistant REST and WebSocket API docs.
 - `v2.x` releases may add new helpers/options and bug fixes, but will not introduce intentional breaking API changes.
 - Breaking API changes will be introduced only in a new major version (for example `v3`).
 - The package targets official Home Assistant REST and WebSocket APIs and follows their documented behavior where possible.
-- Minimum supported Go version is `1.25.8+` (see CI/tooling in this repository).
+- Minimum supported Go version is `1.25.9+` (see CI/tooling in this repository).
 - Security issues should be reported using the process in [`SECURITY.md`](SECURITY.md).
 
 ### Non-goals

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,29 @@
 # Release Notes
 
+## v2.1.1
+
+Security and tooling maintenance release for `v2`.
+
+### Highlights
+- Bump minimum Go version, module toolchain, and CI runtime from `1.25.8` to `1.25.9`.
+- Resolve remaining reachable `govulncheck` findings from the Go standard library by running/building with patched Go release:
+  - GO-2026-4946 (`crypto/x509`)
+  - GO-2026-4947 (`crypto/x509`)
+  - GO-2026-4870 (`crypto/tls`)
+
+### Compatibility
+- No public API changes.
+- No import path changes (`github.com/mkelcik/go-ha-client/v2`).
+- Existing `v2.x` integrations should continue to work without code changes.
+
+### Upgrade Notes
+- Ensure local/dev/CI environments use Go `1.25.9+`.
+- If your pipeline pins Go patch versions, update them to `1.25.9` or newer.
+
+### Verification Summary
+- `go test ./...` passes.
+- `govulncheck ./...` reports no reachable vulnerabilities on Go `1.25.9`.
+
 ## v2.1.0
 
 Security and tooling maintenance release for `v2`.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/mkelcik/go-ha-client/v2
 
 go 1.25
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## Summary

Bump the project toolchain and CI/runtime baseline from Go `1.25.8` to `1.25.9`.

This clears the remaining reachable `govulncheck` findings on `main`, which were coming from the Go standard library rather than project-specific code.

## Changes

- update `go.mod` toolchain to `go1.25.9`
- update GitHub Actions jobs to run on Go `1.25.9`
- bump documented minimum supported Go version to `1.25.9+`
- add release notes for `v2.1.1`
- update changelog entries to reflect the `1.25.9` security bump

## Why

`govulncheck` on `origin/main` with Go `1.25.8` still reported reachable stdlib vulnerabilities:

- `GO-2026-4946` in `crypto/x509`
- `GO-2026-4947` in `crypto/x509`
- `GO-2026-4870` in `crypto/tls`

These are fixed in Go `1.25.9`.

## Validation

- `go test ./...`
- `GOTOOLCHAIN=go1.25.9 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...`

Result:
- `No vulnerabilities found.`
