### PR TITLE
feat: full WebSocket API coverage matching official HA docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [v2.2.0] - 2026-04-20
+
+### Added
+- Typed WebSocket helpers covering every command documented in the official WebSocket API:
+  - `WSClient.DeclareSupportedFeatures` (opt-in `supported_features`; Connect still never sends it automatically).
+  - `WSClient.GetPanels` (`get_panels`).
+  - `WSClient.ValidateConfig` (`validate_config`).
+  - `WSClient.ExtractFromTarget` (`extract_from_target`).
+  - `WSClient.GetTriggersForTarget`, `GetConditionsForTarget`, `GetServicesForTarget` (`get_*_for_target`).
+  - `WSClient.ListEntityRegistryForDisplay` (`config/entity_registry/list_for_display`).
+  - `WSClient.ListExposedEntities`, `WSClient.ExposeEntity` (`homeassistant/expose_entity[/list]`).
+- New public types in `types.go`: `Panel`, `Panels`, `TargetSelector`, `ValidateConfigRequest`, `ValidateConfigSectionResult`, `ValidateConfigResult`, `ExtractFromTargetResult`, `TriggerInfo`, `ConditionInfo`, `ServiceTargetInfo`, `DisplayEntity`, `DisplayEntityRegistry`, `ExposedEntitiesResult`, `ExposeEntityRequest`.
+- New sentinel `ErrEmptyTarget` for empty target selectors.
+- Runnable examples: `examples/ws_panels`, `examples/ws_validate_config`, `examples/ws_entity_registry`, `examples/ws_expose_entity`, `examples/ws_target_helpers`, `examples/ws_supported_features`.
+- README section listing the full WebSocket command → method mapping.
+
+### Notes
+- Purely additive release; all `v2.1.x` integrations keep working without changes.
+- `Connect()` handshake sequence is unchanged: `supported_features` remains opt-in via `DeclareSupportedFeatures`.
+
 ## [v2.1.2]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
   - `WSClient.ListEntityRegistryForDisplay` (`config/entity_registry/list_for_display`).
   - `WSClient.ListExposedEntities`, `WSClient.ExposeEntity` (`homeassistant/expose_entity[/list]`).
 - New public types in `types.go`: `Panel`, `Panels`, `TargetSelector`, `ValidateConfigRequest`, `ValidateConfigSectionResult`, `ValidateConfigResult`, `ExtractFromTargetResult`, `TriggerInfo`, `ConditionInfo`, `ServiceTargetInfo`, `DisplayEntity`, `DisplayEntityRegistry`, `ExposedEntitiesResult`, `ExposeEntityRequest`.
-- New sentinel `ErrEmptyTarget` for empty target selectors.
+- New sentinels `ErrEmptyTarget` and `ErrEmptyAssistants` for empty target selectors and `ExposeEntity` calls without target assistants.
 - Runnable examples: `examples/ws_panels`, `examples/ws_validate_config`, `examples/ws_entity_registry`, `examples/ws_expose_entity`, `examples/ws_target_helpers`, `examples/ws_supported_features`.
 - README section listing the full WebSocket command → method mapping.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
   - `WSClient.GetTriggersForTarget`, `GetConditionsForTarget`, `GetServicesForTarget` (`get_*_for_target`).
   - `WSClient.ListEntityRegistryForDisplay` (`config/entity_registry/list_for_display`).
   - `WSClient.ListExposedEntities`, `WSClient.ExposeEntity` (`homeassistant/expose_entity[/list]`).
-- New public types in `types.go`: `Panel`, `Panels`, `TargetSelector`, `ValidateConfigRequest`, `ValidateConfigSectionResult`, `ValidateConfigResult`, `ExtractFromTargetResult`, `TriggerInfo`, `ConditionInfo`, `ServiceTargetInfo`, `DisplayEntity`, `DisplayEntityRegistry`, `ExposedEntitiesResult`, `ExposeEntityRequest`.
+- New public types in `types.go`: `Panel`, `Panels`, `TargetSelector`, `ValidateConfigRequest`, `ValidateConfigSectionResult`, `ValidateConfigResult`, `ExtractFromTargetResult`, `DisplayEntity`, `DisplayEntityRegistry`, `ExposedEntitiesResult`, `ExposeEntityRequest`.
+- `readLoop` now accepts coalesced (JSON array) frames in addition to single-object frames, so `DeclareSupportedFeatures` with `coalesce_messages` is usable.
 - New sentinels `ErrEmptyTarget` and `ErrEmptyAssistants` for empty target selectors and `ExposeEntity` calls without target assistants.
 - Runnable examples: `examples/ws_panels`, `examples/ws_validate_config`, `examples/ws_entity_registry`, `examples/ws_expose_entity`, `examples/ws_target_helpers`, `examples/ws_supported_features`.
 - README section listing the full WebSocket command → method mapping.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,14 @@
 # Migration Guide
 
+## v2.1.x -> v2.2.0
+
+No migration required. `v2.2.0` is a purely additive release:
+- Adds typed WebSocket helpers for every command in the official WebSocket API docs (`GetPanels`, `ValidateConfig`, `ExtractFromTarget`, `GetTriggersForTarget`, `GetConditionsForTarget`, `GetServicesForTarget`, `ListEntityRegistryForDisplay`, `ListExposedEntities`, `ExposeEntity`, `DeclareSupportedFeatures`).
+- Adds new public types and a new sentinel error `ErrEmptyTarget`.
+- Does not change any existing method signatures, types, or the `Connect()` handshake (`supported_features` is opt-in, never sent automatically).
+
+Upgrade by bumping the dependency version and rerunning tests.
+
 ## v2.0.0-beta.x -> v2.0.0
 
 - No module path change (`github.com/mkelcik/go-ha-client/v2` stays the same).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,7 +4,7 @@
 
 No migration required. `v2.2.0` is a purely additive release:
 - Adds typed WebSocket helpers for every command in the official WebSocket API docs (`GetPanels`, `ValidateConfig`, `ExtractFromTarget`, `GetTriggersForTarget`, `GetConditionsForTarget`, `GetServicesForTarget`, `ListEntityRegistryForDisplay`, `ListExposedEntities`, `ExposeEntity`, `DeclareSupportedFeatures`).
-- Adds new public types and a new sentinel error `ErrEmptyTarget`.
+- Adds new public types and new sentinel errors `ErrEmptyTarget` and `ErrEmptyAssistants`.
 - Does not change any existing method signatures, types, or the `Connect()` handshake (`supported_features` is opt-in, never sent automatically).
 
 Upgrade by bumping the dependency version and rerunning tests.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,36 @@ The `examples` folder also includes:
 - CallServiceForEntity helper usage (REST and WebSocket)
 - State-changed subscription helpers for single or multiple entities
 - Typed call_service event decoding helper usage
+- Full WebSocket command coverage: panels, config validation, entity registry, voice-assistant expose, target helpers, supported features
+
+### Supported WebSocket commands
+The client exposes typed helpers for every command documented in the official
+[WebSocket API docs](https://developers.home-assistant.io/docs/api/websocket):
+
+| Command | Method |
+|---|---|
+| `auth` / `auth_ok` / `auth_invalid` | `WSClient.Connect` |
+| `ping` / `pong` | `WSClient.Ping` |
+| `supported_features` | `WSClient.DeclareSupportedFeatures` (opt-in) |
+| `get_states` | `WSClient.GetStates` |
+| `get_config` | `WSClient.GetConfig` |
+| `get_services` | `WSClient.GetServices` |
+| `get_panels` | `WSClient.GetPanels` |
+| `fire_event` | `WSClient.FireEvent` |
+| `call_service` | `WSClient.CallService`, `WSClient.CallServiceWithResponse` |
+| `subscribe_events` | `WSClient.SubscribeEvents` |
+| `subscribe_trigger` | `WSClient.SubscribeTrigger` |
+| `unsubscribe_events` | `WSSubscription.Unsubscribe` |
+| `validate_config` | `WSClient.ValidateConfig` |
+| `extract_from_target` | `WSClient.ExtractFromTarget` |
+| `get_triggers_for_target` | `WSClient.GetTriggersForTarget` |
+| `get_conditions_for_target` | `WSClient.GetConditionsForTarget` |
+| `get_services_for_target` | `WSClient.GetServicesForTarget` |
+| `config/entity_registry/list_for_display` | `WSClient.ListEntityRegistryForDisplay` |
+| `homeassistant/expose_entity/list` | `WSClient.ListExposedEntities` |
+| `homeassistant/expose_entity` | `WSClient.ExposeEntity` |
+
+Any additional or future commands can be sent directly via `WSClient.Do(ctx, req, &out)`.
 
 ### WebSocket notes
 - `WithOnReconnect` and `WithOnReconnectError` callbacks are called synchronously from the reconnect loop.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ Recommended first runs:
 - [`examples/helpers_light_commands`](examples/helpers_light_commands) - quick tour of command/entity helper functions.
 - [`examples/helpers_decode_event_data`](examples/helpers_decode_event_data) - simple `DecodeEventData` helper demo (offline).
 
+WebSocket command coverage (added in v2.2.0):
+- [`examples/ws_panels`](examples/ws_panels) - list registered UI panels with `GetPanels`.
+- [`examples/ws_validate_config`](examples/ws_validate_config) - validate trigger/condition/action configs with `ValidateConfig` (valid and invalid cases).
+- [`examples/ws_entity_registry`](examples/ws_entity_registry) - fetch the UI-optimised entity registry with `ListEntityRegistryForDisplay`.
+- [`examples/ws_expose_entity`](examples/ws_expose_entity) - list and set voice-assistant exposure with `ListExposedEntities` / `ExposeEntity`.
+- [`examples/ws_target_helpers`](examples/ws_target_helpers) - resolve targets and inspect applicable triggers/conditions/services.
+- [`examples/ws_supported_features`](examples/ws_supported_features) - opt-in message coalescing via `DeclareSupportedFeatures`.
+
 The `examples` folder also includes:
 - Template rendering
 - History query builder usage
@@ -170,7 +178,6 @@ The `examples` folder also includes:
 - CallServiceForEntity helper usage (REST and WebSocket)
 - State-changed subscription helpers for single or multiple entities
 - Typed call_service event decoding helper usage
-- Full WebSocket command coverage: panels, config validation, entity registry, voice-assistant expose, target helpers, supported features
 
 ### Supported WebSocket commands
 The client exposes typed helpers for every command documented in the official

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,30 @@
 # Release Notes
 
+## v2.2.0
+
+Parity release: the WebSocket client now exposes typed helpers for every command documented on the official [WebSocket API page](https://developers.home-assistant.io/docs/api/websocket).
+
+### Highlights
+- New typed methods on `WSClient`: `DeclareSupportedFeatures`, `GetPanels`, `ValidateConfig`, `ExtractFromTarget`, `GetTriggersForTarget`, `GetConditionsForTarget`, `GetServicesForTarget`, `ListEntityRegistryForDisplay`, `ListExposedEntities`, `ExposeEntity`.
+- New public types for requests and responses (see `CHANGELOG.md`).
+- New sentinel error `ErrEmptyTarget` for empty `TargetSelector` inputs.
+- Six new runnable examples under `examples/` covering every new method.
+- REST API coverage confirmed to be 100% against the official REST docs; no REST changes.
+
+### Compatibility
+- Purely additive. No public method signatures changed, no existing types changed.
+- `Connect()` handshake is unchanged; `supported_features` remains opt-in via `DeclareSupportedFeatures` so existing integrations behave identically.
+- `WSClient.Do(ctx, req, out)` continues to work for any command, including the ones that now have typed wrappers.
+- No `go.mod` changes (still `gorilla/websocket v1.5.3`, minimum Go `1.25.10`).
+
+### Upgrade Notes
+- No code changes required when upgrading from `v2.1.x` to `v2.2.0`.
+- If you were calling any of the new WebSocket commands through raw `Do(...)`, you can optionally migrate to the typed wrappers.
+
+### Verification Summary
+- `go build ./...`, `go vet ./...` pass.
+- `go test ./... -race -count=1` passes, including new per-command unit tests and regression tests (`TestWSClient_Connect_NoAutoSupportedFeatures`, `TestWSClient_Do_StillWorks_ForNewCommands`).
+
 ## v2.1.2
 
 Security and tooling maintenance release for `v2`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ Parity release: the WebSocket client now exposes typed helpers for every command
 ### Highlights
 - New typed methods on `WSClient`: `DeclareSupportedFeatures`, `GetPanels`, `ValidateConfig`, `ExtractFromTarget`, `GetTriggersForTarget`, `GetConditionsForTarget`, `GetServicesForTarget`, `ListEntityRegistryForDisplay`, `ListExposedEntities`, `ExposeEntity`.
 - New public types for requests and responses (see `CHANGELOG.md`).
-- New sentinel error `ErrEmptyTarget` for empty `TargetSelector` inputs.
+- New sentinel errors `ErrEmptyTarget` (empty `TargetSelector` inputs) and `ErrEmptyAssistants` (empty assistants slice in `ExposeEntity`).
 - Six new runnable examples under `examples/` covering every new method.
 - REST API coverage confirmed to be 100% against the official REST docs; no REST changes.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,12 @@ go run ./examples/rest_ping
 - `examples/ws_auto_reconnect`: Subscribe to events with auto-reconnect callbacks.
 - `examples/ws_call_service_for_entity`: Use helper `CallServiceForEntity` with brightness.
 - `examples/ws_watch_call_service_events`: Watch `call_service` events and decode with `WSEvent.CallServiceEvent`.
+- `examples/ws_panels`: List registered UI panels (`GetPanels`).
+- `examples/ws_validate_config`: Validate trigger/condition/action configs (`ValidateConfig`).
+- `examples/ws_entity_registry`: Fetch the lightweight entity registry for UI display (`ListEntityRegistryForDisplay`).
+- `examples/ws_expose_entity`: List and set voice-assistant exposure (`ListExposedEntities`, `ExposeEntity`).
+- `examples/ws_target_helpers`: Resolve targets and inspect applicable triggers/conditions/services (`ExtractFromTarget`, `GetTriggersForTarget`, `GetConditionsForTarget`, `GetServicesForTarget`).
+- `examples/ws_supported_features`: Opt-in message coalescing via `DeclareSupportedFeatures`.
 
 ## Helper examples
 

--- a/examples/ws_entity_registry/main.go
+++ b/examples/ws_entity_registry/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	ha "github.com/mkelcik/go-ha-client/v2"
+)
+
+const (
+	// Replace with your Home Assistant URL and long-lived token.
+	haHost       = "http://homeassistant.local:8123"
+	haToken      = "YOUR_LONG_LIVED_TOKEN"
+	filterDomain = "light" // print only entities in this domain; empty = all
+)
+
+func main() {
+	client, err := ha.NewClient(haHost,
+		ha.WithToken(haToken),
+		ha.WithTimeout(30*time.Second),
+	)
+	if err != nil {
+		log.Fatalf("create client: %v", err)
+	}
+
+	ws := client.WS()
+	if err := ws.Connect(context.Background()); err != nil {
+		log.Fatalf("ws connect failed: %v", err)
+	}
+	defer ws.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	reg, err := ws.ListEntityRegistryForDisplay(ctx)
+	if err != nil {
+		log.Fatalf("list for display: %v", err)
+	}
+
+	fmt.Printf("Registry entries: %d\n", len(reg.Entities))
+	for _, e := range reg.Entities {
+		// Home Assistant uses short keys in this payload; "ei" is entity_id.
+		entityID, _ := e["ei"].(string)
+		if filterDomain != "" && !strings.HasPrefix(entityID, filterDomain+".") {
+			continue
+		}
+		fmt.Printf("  %s\n", entityID)
+	}
+}

--- a/examples/ws_expose_entity/main.go
+++ b/examples/ws_expose_entity/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	ha "github.com/mkelcik/go-ha-client/v2"
+)
+
+const (
+	// Replace with your Home Assistant URL and long-lived token.
+	haHost   = "http://homeassistant.local:8123"
+	haToken  = "YOUR_LONG_LIVED_TOKEN"
+	entityID = "light.kitchen"
+)
+
+func main() {
+	client, err := ha.NewClient(haHost,
+		ha.WithToken(haToken),
+		ha.WithTimeout(30*time.Second),
+	)
+	if err != nil {
+		log.Fatalf("create client: %v", err)
+	}
+
+	ws := client.WS()
+	if err := ws.Connect(context.Background()); err != nil {
+		log.Fatalf("ws connect failed: %v", err)
+	}
+	defer ws.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// List current exposure map.
+	exposed, err := ws.ListExposedEntities(ctx)
+	if err != nil {
+		log.Fatalf("list exposed: %v", err)
+	}
+	fmt.Printf("current exposure for %s: %+v\n", entityID, exposed.ExposedEntities[entityID])
+
+	// Expose entity to the conversation assistant.
+	err = ws.ExposeEntity(ctx, ha.ExposeEntityRequest{
+		Assistants:   []string{"conversation"},
+		EntityIDs:    []string{entityID},
+		ShouldExpose: true,
+	})
+	if err != nil {
+		log.Fatalf("expose entity: %v", err)
+	}
+	fmt.Printf("exposed %s to conversation assistant\n", entityID)
+}

--- a/examples/ws_panels/main.go
+++ b/examples/ws_panels/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	ha "github.com/mkelcik/go-ha-client/v2"
+)
+
+const (
+	// Replace with your Home Assistant URL and long-lived token.
+	haHost  = "http://homeassistant.local:8123"
+	haToken = "YOUR_LONG_LIVED_TOKEN"
+)
+
+func main() {
+	client, err := ha.NewClient(haHost,
+		ha.WithToken(haToken),
+		ha.WithTimeout(30*time.Second),
+	)
+	if err != nil {
+		log.Fatalf("create client: %v", err)
+	}
+
+	ws := client.WS()
+	if err := ws.Connect(context.Background()); err != nil {
+		log.Fatalf("ws connect failed: %v", err)
+	}
+	defer ws.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	panels, err := ws.GetPanels(ctx)
+	if err != nil {
+		log.Fatalf("get panels failed: %v", err)
+	}
+
+	fmt.Printf("Registered panels: %d\n", len(panels))
+	for urlPath, panel := range panels {
+		fmt.Printf("  %-20s component=%-20s admin=%t icon=%s\n",
+			urlPath, panel.ComponentName, panel.RequireAdmin, panel.Icon)
+	}
+}

--- a/examples/ws_supported_features/main.go
+++ b/examples/ws_supported_features/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	ha "github.com/mkelcik/go-ha-client/v2"
+)
+
+const (
+	// Replace with your Home Assistant URL and long-lived token.
+	haHost  = "http://homeassistant.local:8123"
+	haToken = "YOUR_LONG_LIVED_TOKEN"
+)
+
+func main() {
+	client, err := ha.NewClient(haHost,
+		ha.WithToken(haToken),
+		ha.WithTimeout(30*time.Second),
+	)
+	if err != nil {
+		log.Fatalf("create client: %v", err)
+	}
+
+	ws := client.WS()
+	if err := ws.Connect(context.Background()); err != nil {
+		log.Fatalf("ws connect failed: %v", err)
+	}
+	defer ws.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Opt-in: advertise support for message coalescing. Must be called
+	// explicitly; Connect never sends supported_features automatically so that
+	// existing integrations keep their exact handshake sequence.
+	if err := ws.DeclareSupportedFeatures(ctx, map[string]interface{}{
+		"coalesce_messages": 1,
+	}); err != nil {
+		log.Fatalf("declare supported features: %v", err)
+	}
+	fmt.Println("supported_features declared: coalesce_messages=1")
+}

--- a/examples/ws_target_helpers/main.go
+++ b/examples/ws_target_helpers/main.go
@@ -39,7 +39,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("extract from target: %v", err)
 	}
-	fmt.Printf("extracted entities: %v\n", extracted.EntityIDs)
+	fmt.Printf("extracted entities: %v\n", extracted.ReferencedEntities)
 
 	triggers, err := ws.GetTriggersForTarget(ctx, target, true)
 	if err != nil {

--- a/examples/ws_target_helpers/main.go
+++ b/examples/ws_target_helpers/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	ha "github.com/mkelcik/go-ha-client/v2"
+)
+
+const (
+	// Replace with your Home Assistant URL and long-lived token.
+	haHost  = "http://homeassistant.local:8123"
+	haToken = "YOUR_LONG_LIVED_TOKEN"
+)
+
+func main() {
+	client, err := ha.NewClient(haHost,
+		ha.WithToken(haToken),
+		ha.WithTimeout(30*time.Second),
+	)
+	if err != nil {
+		log.Fatalf("create client: %v", err)
+	}
+
+	ws := client.WS()
+	if err := ws.Connect(context.Background()); err != nil {
+		log.Fatalf("ws connect failed: %v", err)
+	}
+	defer ws.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	target := ha.TargetSelector{EntityID: []string{"light.kitchen"}}
+
+	extracted, err := ws.ExtractFromTarget(ctx, target, false)
+	if err != nil {
+		log.Fatalf("extract from target: %v", err)
+	}
+	fmt.Printf("extracted entities: %v\n", extracted.EntityIDs)
+
+	triggers, err := ws.GetTriggersForTarget(ctx, target, true)
+	if err != nil {
+		log.Fatalf("get triggers: %v", err)
+	}
+	fmt.Printf("triggers: %d\n", len(triggers))
+
+	conditions, err := ws.GetConditionsForTarget(ctx, target, true)
+	if err != nil {
+		log.Fatalf("get conditions: %v", err)
+	}
+	fmt.Printf("conditions: %d\n", len(conditions))
+
+	services, err := ws.GetServicesForTarget(ctx, target, true)
+	if err != nil {
+		log.Fatalf("get services: %v", err)
+	}
+	fmt.Printf("services: %d\n", len(services))
+}

--- a/examples/ws_validate_config/main.go
+++ b/examples/ws_validate_config/main.go
@@ -45,9 +45,12 @@ func main() {
 	}
 	fmt.Printf("valid trigger result: %+v\n", res.Trigger)
 
-	// Intentionally invalid action (missing service).
+	// Intentionally invalid action: references a service that does not exist.
+	// HA responds with {valid: false, error: "..."} for unknown services.
 	res, err = ws.ValidateConfig(ctx, ha.ValidateConfigRequest{
-		Action: map[string]interface{}{"service": ""},
+		Action: map[string]interface{}{
+			"service": "this_domain_does_not_exist.nope",
+		},
 	})
 	if err != nil {
 		log.Fatalf("validate invalid action: %v", err)

--- a/examples/ws_validate_config/main.go
+++ b/examples/ws_validate_config/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	ha "github.com/mkelcik/go-ha-client/v2"
+)
+
+const (
+	// Replace with your Home Assistant URL and long-lived token.
+	haHost  = "http://homeassistant.local:8123"
+	haToken = "YOUR_LONG_LIVED_TOKEN"
+)
+
+func main() {
+	client, err := ha.NewClient(haHost,
+		ha.WithToken(haToken),
+		ha.WithTimeout(30*time.Second),
+	)
+	if err != nil {
+		log.Fatalf("create client: %v", err)
+	}
+
+	ws := client.WS()
+	if err := ws.Connect(context.Background()); err != nil {
+		log.Fatalf("ws connect failed: %v", err)
+	}
+	defer ws.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Valid state trigger.
+	res, err := ws.ValidateConfig(ctx, ha.ValidateConfigRequest{
+		Trigger: map[string]interface{}{
+			"platform":  "state",
+			"entity_id": "light.kitchen",
+		},
+	})
+	if err != nil {
+		log.Fatalf("validate valid trigger: %v", err)
+	}
+	fmt.Printf("valid trigger result: %+v\n", res.Trigger)
+
+	// Intentionally invalid action (missing service).
+	res, err = ws.ValidateConfig(ctx, ha.ValidateConfigRequest{
+		Action: map[string]interface{}{"service": ""},
+	})
+	if err != nil {
+		log.Fatalf("validate invalid action: %v", err)
+	}
+	fmt.Printf("invalid action result: %+v\n", res.Action)
+}

--- a/types.go
+++ b/types.go
@@ -449,3 +449,102 @@ func createLogbookParams(filter *LogbookFilter) url.Values {
 	}
 	return queryParams
 }
+
+// Panel represents a single Home Assistant UI panel registration as returned by the
+// WebSocket command get_panels.
+type Panel struct {
+	ComponentName string                 `json:"component_name"`
+	Icon          string                 `json:"icon,omitempty"`
+	Title         string                 `json:"title,omitempty"`
+	Config        map[string]interface{} `json:"config,omitempty"`
+	URLPath       string                 `json:"url_path"`
+	RequireAdmin  bool                   `json:"require_admin"`
+}
+
+// Panels is the map of panel URL paths to panel registrations returned by get_panels.
+type Panels map[string]Panel
+
+// TargetSelector is the Home Assistant target selector used by service calls and
+// the WebSocket target helpers (extract_from_target, get_*_for_target).
+type TargetSelector struct {
+	EntityID []string `json:"entity_id,omitempty"`
+	DeviceID []string `json:"device_id,omitempty"`
+	AreaID   []string `json:"area_id,omitempty"`
+	FloorID  []string `json:"floor_id,omitempty"`
+	LabelID  []string `json:"label_id,omitempty"`
+}
+
+// IsEmpty reports whether the selector holds no references.
+func (t TargetSelector) IsEmpty() bool {
+	return len(t.EntityID) == 0 && len(t.DeviceID) == 0 && len(t.AreaID) == 0 &&
+		len(t.FloorID) == 0 && len(t.LabelID) == 0
+}
+
+// ValidateConfigRequest is the request body for the validate_config WebSocket command.
+// All three sections are optional and are validated independently.
+type ValidateConfigRequest struct {
+	Trigger   interface{} `json:"trigger,omitempty"`
+	Condition interface{} `json:"condition,omitempty"`
+	Action    interface{} `json:"action,omitempty"`
+}
+
+// ValidateConfigSectionResult is the validation outcome for a single section
+// (trigger, condition or action) in the validate_config response.
+type ValidateConfigSectionResult struct {
+	Valid bool   `json:"valid"`
+	Error string `json:"error,omitempty"`
+}
+
+// ValidateConfigResult is the full response for validate_config; any missing
+// sections in the request are nil in the result.
+type ValidateConfigResult struct {
+	Trigger   *ValidateConfigSectionResult `json:"trigger,omitempty"`
+	Condition *ValidateConfigSectionResult `json:"condition,omitempty"`
+	Action    *ValidateConfigSectionResult `json:"action,omitempty"`
+}
+
+// ExtractFromTargetResult lists the concrete entities/devices/areas/etc. that
+// a target selector resolves to, as returned by extract_from_target.
+type ExtractFromTargetResult struct {
+	EntityIDs []string `json:"entity_ids,omitempty"`
+	DeviceIDs []string `json:"device_ids,omitempty"`
+	AreaIDs   []string `json:"area_ids,omitempty"`
+	FloorIDs  []string `json:"floor_ids,omitempty"`
+	LabelIDs  []string `json:"label_ids,omitempty"`
+}
+
+// TriggerInfo describes a trigger applicable to a target as returned by
+// get_triggers_for_target. Kept as a flexible map because the shape depends
+// on the trigger platform.
+type TriggerInfo map[string]interface{}
+
+// ConditionInfo describes a condition applicable to a target as returned by
+// get_conditions_for_target.
+type ConditionInfo map[string]interface{}
+
+// ServiceTargetInfo describes a service applicable to a target as returned by
+// get_services_for_target.
+type ServiceTargetInfo map[string]interface{}
+
+// DisplayEntity is a lightweight entity registry entry optimised for UI display
+// (short field names, only enabled entities). Exact fields depend on the HA
+// version so it is exposed as a flexible map.
+type DisplayEntity map[string]interface{}
+
+// DisplayEntityRegistry is the response for config/entity_registry/list_for_display.
+type DisplayEntityRegistry struct {
+	Entities []DisplayEntity `json:"entities"`
+}
+
+// ExposedEntitiesResult is the response for homeassistant/expose_entity/list.
+// The outer key is an entity_id, the inner map is assistant name -> exposed.
+type ExposedEntitiesResult struct {
+	ExposedEntities map[string]map[string]bool `json:"exposed_entities"`
+}
+
+// ExposeEntityRequest is the request body for homeassistant/expose_entity.
+type ExposeEntityRequest struct {
+	Assistants   []string `json:"assistants"`
+	EntityIDs    []string `json:"entity_ids"`
+	ShouldExpose bool     `json:"should_expose"`
+}

--- a/types.go
+++ b/types.go
@@ -514,16 +514,19 @@ type ExtractFromTargetResult struct {
 }
 
 // TriggerInfo describes a trigger applicable to a target as returned by
-// get_triggers_for_target. Kept as a flexible map because the shape depends
-// on the trigger platform.
+// get_triggers_for_target. Kept as a flexible map because the fields
+// depend on the trigger platform; read values with type assertions,
+// for example t["platform"].(string).
 type TriggerInfo map[string]interface{}
 
 // ConditionInfo describes a condition applicable to a target as returned by
-// get_conditions_for_target.
+// get_conditions_for_target. Kept as a flexible map because the fields
+// depend on the condition type; read values with type assertions.
 type ConditionInfo map[string]interface{}
 
 // ServiceTargetInfo describes a service applicable to a target as returned by
-// get_services_for_target.
+// get_services_for_target. Kept as a flexible map because the fields
+// depend on the service/domain; read values with type assertions.
 type ServiceTargetInfo map[string]interface{}
 
 // DisplayEntity is a lightweight entity registry entry optimised for UI display

--- a/types.go
+++ b/types.go
@@ -504,39 +504,33 @@ type ValidateConfigResult struct {
 }
 
 // ExtractFromTargetResult lists the concrete entities/devices/areas/etc. that
-// a target selector resolves to, as returned by extract_from_target.
+// a target selector resolves to, as returned by extract_from_target. Field
+// names match the HA WebSocket docs.
 type ExtractFromTargetResult struct {
-	EntityIDs []string `json:"entity_ids,omitempty"`
-	DeviceIDs []string `json:"device_ids,omitempty"`
-	AreaIDs   []string `json:"area_ids,omitempty"`
-	FloorIDs  []string `json:"floor_ids,omitempty"`
-	LabelIDs  []string `json:"label_ids,omitempty"`
+	ReferencedEntities []string `json:"referenced_entities,omitempty"`
+	ReferencedDevices  []string `json:"referenced_devices,omitempty"`
+	ReferencedAreas    []string `json:"referenced_areas,omitempty"`
+	MissingDevices     []string `json:"missing_devices,omitempty"`
+	MissingAreas       []string `json:"missing_areas,omitempty"`
+	MissingFloors      []string `json:"missing_floors,omitempty"`
+	MissingLabels      []string `json:"missing_labels,omitempty"`
 }
-
-// TriggerInfo describes a trigger applicable to a target as returned by
-// get_triggers_for_target. Kept as a flexible map because the fields
-// depend on the trigger platform; read values with type assertions,
-// for example t["platform"].(string).
-type TriggerInfo map[string]interface{}
-
-// ConditionInfo describes a condition applicable to a target as returned by
-// get_conditions_for_target. Kept as a flexible map because the fields
-// depend on the condition type; read values with type assertions.
-type ConditionInfo map[string]interface{}
-
-// ServiceTargetInfo describes a service applicable to a target as returned by
-// get_services_for_target. Kept as a flexible map because the fields
-// depend on the service/domain; read values with type assertions.
-type ServiceTargetInfo map[string]interface{}
 
 // DisplayEntity is a lightweight entity registry entry optimised for UI display
 // (short field names, only enabled entities). Exact fields depend on the HA
 // version so it is exposed as a flexible map.
+//
+// The "ec" key, when present, is an index into DisplayEntityRegistry.EntityCategories
+// rather than the category name itself.
 type DisplayEntity map[string]interface{}
 
 // DisplayEntityRegistry is the response for config/entity_registry/list_for_display.
+// EntityCategories maps the compact integer indices used in the "ec" field of
+// each DisplayEntity to the human-readable category name (e.g. "config", "diagnostic").
+// JSON object keys are strings, so the integer indices are exposed as strings here.
 type DisplayEntityRegistry struct {
-	Entities []DisplayEntity `json:"entities"`
+	EntityCategories map[string]string `json:"entity_categories,omitempty"`
+	Entities         []DisplayEntity   `json:"entities"`
 }
 
 // ExposedEntitiesResult is the response for homeassistant/expose_entity/list.

--- a/types_test.go
+++ b/types_test.go
@@ -260,3 +260,95 @@ func TestHistoryQueryBuilder(t *testing.T) {
 		t.Fatalf("missing significant_changes_only in %q", got)
 	}
 }
+
+func TestPanelsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"lovelace":{"component_name":"lovelace","url_path":"lovelace","require_admin":false},"config":{"component_name":"config","icon":"mdi:cog","url_path":"config","require_admin":true}}`
+	var panels Panels
+	if err := json.Unmarshal([]byte(raw), &panels); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if panels["config"].Icon != "mdi:cog" || !panels["config"].RequireAdmin {
+		t.Fatalf("unexpected config panel: %#v", panels["config"])
+	}
+	if panels["lovelace"].ComponentName != "lovelace" {
+		t.Fatalf("unexpected lovelace panel: %#v", panels["lovelace"])
+	}
+}
+
+func TestValidateConfigResultRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"trigger":{"valid":true},"action":{"valid":false,"error":"unknown"}}`
+	var res ValidateConfigResult
+	if err := json.Unmarshal([]byte(raw), &res); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if res.Trigger == nil || !res.Trigger.Valid {
+		t.Fatalf("unexpected trigger: %#v", res.Trigger)
+	}
+	if res.Action == nil || res.Action.Valid || res.Action.Error != "unknown" {
+		t.Fatalf("unexpected action: %#v", res.Action)
+	}
+	if res.Condition != nil {
+		t.Fatalf("expected nil condition, got %#v", res.Condition)
+	}
+}
+
+func TestTargetSelector_IsEmpty(t *testing.T) {
+	t.Parallel()
+
+	if !(TargetSelector{}).IsEmpty() {
+		t.Fatal("expected empty selector")
+	}
+	if (TargetSelector{EntityID: []string{"light.kitchen"}}).IsEmpty() {
+		t.Fatal("selector with entity should not be empty")
+	}
+	if (TargetSelector{FloorID: []string{"ground"}}).IsEmpty() {
+		t.Fatal("selector with floor should not be empty")
+	}
+}
+
+func TestTargetSelectorJSONOmitsEmpty(t *testing.T) {
+	t.Parallel()
+
+	sel := TargetSelector{AreaID: []string{"kitchen"}}
+	b, err := json.Marshal(sel)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(b) != `{"area_id":["kitchen"]}` {
+		t.Fatalf("unexpected json: %s", string(b))
+	}
+}
+
+func TestExposedEntitiesResultRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"exposed_entities":{"light.kitchen":{"conversation":true,"cloud.alexa":false}}}`
+	var res ExposedEntitiesResult
+	if err := json.Unmarshal([]byte(raw), &res); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	entry := res.ExposedEntities["light.kitchen"]
+	if !entry["conversation"] || entry["cloud.alexa"] {
+		t.Fatalf("unexpected exposure: %#v", entry)
+	}
+}
+
+func TestExtractFromTargetResultRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"entity_ids":["light.kitchen","switch.kitchen"],"area_ids":["kitchen"]}`
+	var res ExtractFromTargetResult
+	if err := json.Unmarshal([]byte(raw), &res); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(res.EntityIDs) != 2 || res.EntityIDs[1] != "switch.kitchen" {
+		t.Fatalf("unexpected entities: %#v", res.EntityIDs)
+	}
+	if len(res.AreaIDs) != 1 {
+		t.Fatalf("unexpected areas: %#v", res.AreaIDs)
+	}
+}

--- a/types_test.go
+++ b/types_test.go
@@ -340,15 +340,18 @@ func TestExposedEntitiesResultRoundTrip(t *testing.T) {
 func TestExtractFromTargetResultRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	raw := `{"entity_ids":["light.kitchen","switch.kitchen"],"area_ids":["kitchen"]}`
+	raw := `{"referenced_entities":["light.kitchen","switch.kitchen"],"referenced_areas":["kitchen"],"missing_devices":["dev-missing"]}`
 	var res ExtractFromTargetResult
 	if err := json.Unmarshal([]byte(raw), &res); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(res.EntityIDs) != 2 || res.EntityIDs[1] != "switch.kitchen" {
-		t.Fatalf("unexpected entities: %#v", res.EntityIDs)
+	if len(res.ReferencedEntities) != 2 || res.ReferencedEntities[1] != "switch.kitchen" {
+		t.Fatalf("unexpected entities: %#v", res.ReferencedEntities)
 	}
-	if len(res.AreaIDs) != 1 {
-		t.Fatalf("unexpected areas: %#v", res.AreaIDs)
+	if len(res.ReferencedAreas) != 1 {
+		t.Fatalf("unexpected areas: %#v", res.ReferencedAreas)
+	}
+	if len(res.MissingDevices) != 1 || res.MissingDevices[0] != "dev-missing" {
+		t.Fatalf("unexpected missing devices: %#v", res.MissingDevices)
 	}
 }

--- a/ws_client.go
+++ b/ws_client.go
@@ -491,28 +491,31 @@ func (c *WSClient) ExtractFromTarget(ctx context.Context, target TargetSelector,
 	return result, c.Do(ctx, req, &result)
 }
 
-// GetTriggersForTarget returns triggers applicable to a target (get_triggers_for_target).
-// Per docs, expand_group defaults to true for this command.
-func (c *WSClient) GetTriggersForTarget(ctx context.Context, target TargetSelector, expandGroup bool) ([]TriggerInfo, error) {
-	var result []TriggerInfo
+// GetTriggersForTarget returns triggers applicable to a target as a slice of
+// "domain.trigger_name" identifiers (get_triggers_for_target). Per docs,
+// expand_group defaults to true for this command.
+func (c *WSClient) GetTriggersForTarget(ctx context.Context, target TargetSelector, expandGroup bool) ([]string, error) {
+	var result []string
 	if target.IsEmpty() {
 		return nil, ErrEmptyTarget
 	}
 	return result, c.Do(ctx, buildTargetRequest("get_triggers_for_target", target, expandGroup), &result)
 }
 
-// GetConditionsForTarget returns conditions applicable to a target.
-func (c *WSClient) GetConditionsForTarget(ctx context.Context, target TargetSelector, expandGroup bool) ([]ConditionInfo, error) {
-	var result []ConditionInfo
+// GetConditionsForTarget returns conditions applicable to a target as a slice of
+// "domain.condition_name" identifiers.
+func (c *WSClient) GetConditionsForTarget(ctx context.Context, target TargetSelector, expandGroup bool) ([]string, error) {
+	var result []string
 	if target.IsEmpty() {
 		return nil, ErrEmptyTarget
 	}
 	return result, c.Do(ctx, buildTargetRequest("get_conditions_for_target", target, expandGroup), &result)
 }
 
-// GetServicesForTarget returns services applicable to a target.
-func (c *WSClient) GetServicesForTarget(ctx context.Context, target TargetSelector, expandGroup bool) ([]ServiceTargetInfo, error) {
-	var result []ServiceTargetInfo
+// GetServicesForTarget returns services applicable to a target as a slice of
+// "domain.service_name" identifiers.
+func (c *WSClient) GetServicesForTarget(ctx context.Context, target TargetSelector, expandGroup bool) ([]string, error) {
+	var result []string
 	if target.IsEmpty() {
 		return nil, ErrEmptyTarget
 	}
@@ -757,48 +760,88 @@ func (c *WSClient) send(ctx context.Context, req map[string]interface{}) (wsInco
 
 func (c *WSClient) readLoop(conn *websocket.Conn) {
 	for {
-		msg := wsIncomingMessage{}
-		if err := conn.ReadJSON(&msg); err != nil {
-			// Connection lost
-			c.mu.Lock()
-			c.conn = nil
-			c.mu.Unlock()
-
-			// Explicitly close the connection to avoid leaks
-			_ = conn.Close()
-
-			if c.closed.Load() {
-				c.failAll(ErrWSClosed)
-				return
-			}
-
-			if c.reconnect.Enabled {
-				// Fail any pending requests (they won't be valid on new connection)
-				c.failPending(ErrWSClosed)
-				go c.reconnectLoop()
-				return
-			}
-
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) || errors.Is(err, io.EOF) {
-				c.failAll(ErrWSClosed)
-				return
-			}
-			c.failAll(err)
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			c.tearDownReadLoop(conn, err)
 			return
 		}
 
-		if isDebugEnabled(c.config.Logger, context.Background()) {
-			c.config.Logger.Debug("recv", "payload", formatWSLogPayload(msg))
+		// After supported_features enables coalesce_messages, HA may bundle
+		// multiple messages into a single JSON array frame; otherwise each
+		// frame is a single JSON object.
+		msgs, err := decodeIncomingFrame(data)
+		if err != nil {
+			// A malformed frame violates the WebSocket protocol contract; we
+			// cannot recover state for in-flight requests so treat it as fatal.
+			c.tearDownReadLoop(conn, err)
+			return
 		}
 
-		switch msg.Type {
+		for _, msg := range msgs {
+			if isDebugEnabled(c.config.Logger, context.Background()) {
+				c.config.Logger.Debug("recv", "payload", formatWSLogPayload(msg))
+			}
 
-		case "result", "pong":
-			c.dispatchPending(msg)
-		case "event":
-			c.dispatchEvent(msg)
+			switch msg.Type {
+			case "result", "pong":
+				c.dispatchPending(msg)
+			case "event":
+				c.dispatchEvent(msg)
+			}
 		}
 	}
+}
+
+// tearDownReadLoop releases the connection and surfaces err to any pending
+// callers. It mirrors the behavior the read loop had before coalesce-aware
+// decoding was added.
+func (c *WSClient) tearDownReadLoop(conn *websocket.Conn, err error) {
+	c.mu.Lock()
+	c.conn = nil
+	c.mu.Unlock()
+
+	_ = conn.Close()
+
+	if c.closed.Load() {
+		c.failAll(ErrWSClosed)
+		return
+	}
+
+	if c.reconnect.Enabled {
+		c.failPending(ErrWSClosed)
+		go c.reconnectLoop()
+		return
+	}
+
+	if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) || errors.Is(err, io.EOF) {
+		c.failAll(ErrWSClosed)
+		return
+	}
+	c.failAll(err)
+}
+
+// decodeIncomingFrame decodes a single WebSocket text frame, which is either a
+// single JSON object or a JSON array of objects (when coalesce_messages is on).
+func decodeIncomingFrame(data []byte) ([]wsIncomingMessage, error) {
+	for _, b := range data {
+		switch b {
+		case ' ', '\t', '\r', '\n':
+			continue
+		case '[':
+			var batch []wsIncomingMessage
+			if err := json.Unmarshal(data, &batch); err != nil {
+				return nil, err
+			}
+			return batch, nil
+		default:
+			var msg wsIncomingMessage
+			if err := json.Unmarshal(data, &msg); err != nil {
+				return nil, err
+			}
+			return []wsIncomingMessage{msg}, nil
+		}
+	}
+	return nil, nil
 }
 
 // failPending cancels all pending requests but leaves subscriptions intact.

--- a/ws_client.go
+++ b/ws_client.go
@@ -843,6 +843,9 @@ func decodeIncomingFrame(data []byte) ([]wsIncomingMessage, error) {
 			if err := json.Unmarshal(data, &batch); err != nil {
 				return nil, err
 			}
+			if len(batch) == 0 {
+				return nil, fmt.Errorf("empty ws batch")
+			}
 			return batch, nil
 		case '{':
 			var msg wsIncomingMessage

--- a/ws_client.go
+++ b/ws_client.go
@@ -30,6 +30,8 @@ var (
 	ErrWSInvalidRequest = errors.New("ws request must include non-empty type")
 	// ErrEmptyTarget indicates a target selector has no references and cannot be used.
 	ErrEmptyTarget = errors.New("target selector must reference at least one entity/device/area/floor/label")
+	// ErrEmptyAssistants indicates an expose_entity request with no target assistants.
+	ErrEmptyAssistants = errors.New("expose_entity requires at least one assistant")
 )
 
 const wsUnsubscribeTimeout = 5 * time.Second
@@ -427,8 +429,16 @@ func (c *WSClient) CallServiceWithResponse(ctx context.Context, domain, service 
 
 // DeclareSupportedFeatures sends a supported_features message advertising
 // optional client capabilities (for example {"coalesce_messages": 1}).
-// It is opt-in and never called automatically; invoke it explicitly after
-// Connect if you need the features it unlocks.
+//
+// It is opt-in and never sent automatically from Connect, so existing
+// integrations keep an identical handshake sequence. Call it explicitly
+// right after Connect if you need the features it unlocks.
+//
+// Home Assistant documents the first user message as id=1, but any
+// incrementing id (auto-assigned by this client) is accepted in practice.
+//
+// See https://developers.home-assistant.io/docs/api/websocket for the
+// current list of supported feature keys.
 func (c *WSClient) DeclareSupportedFeatures(ctx context.Context, features map[string]interface{}) error {
 	req := map[string]interface{}{
 		"type": "supported_features",
@@ -531,6 +541,9 @@ func (c *WSClient) ListExposedEntities(ctx context.Context) (ExposedEntitiesResu
 // assistants must contain at least one of "conversation", "cloud.alexa",
 // "cloud.google_assistant"; entityIDs must be non-empty.
 func (c *WSClient) ExposeEntity(ctx context.Context, req ExposeEntityRequest) error {
+	if len(req.Assistants) == 0 {
+		return ErrEmptyAssistants
+	}
 	if len(req.EntityIDs) == 0 {
 		return ErrEmptyEntityID
 	}

--- a/ws_client.go
+++ b/ws_client.go
@@ -541,8 +541,10 @@ func (c *WSClient) ListExposedEntities(ctx context.Context) (ExposedEntitiesResu
 }
 
 // ExposeEntity sets voice-assistant exposure for one or more entities.
-// assistants must contain at least one of "conversation", "cloud.alexa",
-// "cloud.google_assistant"; entityIDs must be non-empty.
+// Both Assistants and EntityIDs must be non-empty. Typical Assistants values
+// are "conversation", "cloud.alexa" and "cloud.google_assistant", but the
+// list is not hard-coded so third-party voice integrations are supported;
+// Home Assistant will reject unknown assistants server-side.
 func (c *WSClient) ExposeEntity(ctx context.Context, req ExposeEntityRequest) error {
 	if len(req.Assistants) == 0 {
 		return ErrEmptyAssistants
@@ -760,9 +762,15 @@ func (c *WSClient) send(ctx context.Context, req map[string]interface{}) (wsInco
 
 func (c *WSClient) readLoop(conn *websocket.Conn) {
 	for {
-		_, data, err := conn.ReadMessage()
+		msgType, data, err := conn.ReadMessage()
 		if err != nil {
 			c.tearDownReadLoop(conn, err)
+			return
+		}
+		// HA always sends text frames; anything else is a protocol violation
+		// from the server (or an intermediary) and cannot be JSON-decoded.
+		if msgType != websocket.TextMessage {
+			c.tearDownReadLoop(conn, fmt.Errorf("unexpected ws frame type %d", msgType))
 			return
 		}
 
@@ -820,8 +828,11 @@ func (c *WSClient) tearDownReadLoop(conn *websocket.Conn, err error) {
 	c.failAll(err)
 }
 
-// decodeIncomingFrame decodes a single WebSocket text frame, which is either a
-// single JSON object or a JSON array of objects (when coalesce_messages is on).
+// decodeIncomingFrame decodes a single WebSocket text frame, which must be
+// either a JSON object or a JSON array of objects (the latter when
+// coalesce_messages is on). Any other JSON value (null, number, string,
+// bool) or an empty/whitespace-only frame is treated as a protocol error
+// so callers cannot be silently stranded on a zero-value message.
 func decodeIncomingFrame(data []byte) ([]wsIncomingMessage, error) {
 	for _, b := range data {
 		switch b {
@@ -833,15 +844,17 @@ func decodeIncomingFrame(data []byte) ([]wsIncomingMessage, error) {
 				return nil, err
 			}
 			return batch, nil
-		default:
+		case '{':
 			var msg wsIncomingMessage
 			if err := json.Unmarshal(data, &msg); err != nil {
 				return nil, err
 			}
 			return []wsIncomingMessage{msg}, nil
+		default:
+			return nil, fmt.Errorf("unexpected ws payload, want object or array, got %q", b)
 		}
 	}
-	return nil, nil
+	return nil, fmt.Errorf("empty ws frame")
 }
 
 // failPending cancels all pending requests but leaves subscriptions intact.

--- a/ws_client.go
+++ b/ws_client.go
@@ -28,6 +28,8 @@ var (
 	ErrWSAuthFailed = errors.New("ws authentication failed")
 	// ErrWSInvalidRequest indicates a request is missing a required type.
 	ErrWSInvalidRequest = errors.New("ws request must include non-empty type")
+	// ErrEmptyTarget indicates a target selector has no references and cannot be used.
+	ErrEmptyTarget = errors.New("target selector must reference at least one entity/device/area/floor/label")
 )
 
 const wsUnsubscribeTimeout = 5 * time.Second
@@ -421,6 +423,131 @@ func (c *WSClient) CallServiceWithResponse(ctx context.Context, domain, service 
 		req["service_data"] = data
 	}
 	return result, c.Do(ctx, req, &result)
+}
+
+// DeclareSupportedFeatures sends a supported_features message advertising
+// optional client capabilities (for example {"coalesce_messages": 1}).
+// It is opt-in and never called automatically; invoke it explicitly after
+// Connect if you need the features it unlocks.
+func (c *WSClient) DeclareSupportedFeatures(ctx context.Context, features map[string]interface{}) error {
+	req := map[string]interface{}{
+		"type": "supported_features",
+	}
+	if features != nil {
+		req["features"] = features
+	}
+	return c.Do(ctx, req, nil)
+}
+
+// GetPanels returns the registered UI panels (get_panels).
+func (c *WSClient) GetPanels(ctx context.Context) (Panels, error) {
+	panels := Panels{}
+	return panels, c.Do(ctx, map[string]interface{}{
+		"type": "get_panels",
+	}, &panels)
+}
+
+// ValidateConfig validates trigger/condition/action configurations against the
+// running Home Assistant instance. All three sections are optional.
+func (c *WSClient) ValidateConfig(ctx context.Context, cfg ValidateConfigRequest) (ValidateConfigResult, error) {
+	result := ValidateConfigResult{}
+	req := map[string]interface{}{
+		"type": "validate_config",
+	}
+	if cfg.Trigger != nil {
+		req["trigger"] = cfg.Trigger
+	}
+	if cfg.Condition != nil {
+		req["condition"] = cfg.Condition
+	}
+	if cfg.Action != nil {
+		req["action"] = cfg.Action
+	}
+	return result, c.Do(ctx, req, &result)
+}
+
+// ExtractFromTarget resolves a target selector to concrete entity/device/area/etc. ids.
+// If expandGroup is true, group entities are expanded to their members.
+func (c *WSClient) ExtractFromTarget(ctx context.Context, target TargetSelector, expandGroup bool) (ExtractFromTargetResult, error) {
+	result := ExtractFromTargetResult{}
+	if target.IsEmpty() {
+		return result, ErrEmptyTarget
+	}
+	req := map[string]interface{}{
+		"type":         "extract_from_target",
+		"target":       target,
+		"expand_group": expandGroup,
+	}
+	return result, c.Do(ctx, req, &result)
+}
+
+// GetTriggersForTarget returns triggers applicable to a target (get_triggers_for_target).
+// Per docs, expand_group defaults to true for this command.
+func (c *WSClient) GetTriggersForTarget(ctx context.Context, target TargetSelector, expandGroup bool) ([]TriggerInfo, error) {
+	var result []TriggerInfo
+	if target.IsEmpty() {
+		return nil, ErrEmptyTarget
+	}
+	return result, c.Do(ctx, buildTargetRequest("get_triggers_for_target", target, expandGroup), &result)
+}
+
+// GetConditionsForTarget returns conditions applicable to a target.
+func (c *WSClient) GetConditionsForTarget(ctx context.Context, target TargetSelector, expandGroup bool) ([]ConditionInfo, error) {
+	var result []ConditionInfo
+	if target.IsEmpty() {
+		return nil, ErrEmptyTarget
+	}
+	return result, c.Do(ctx, buildTargetRequest("get_conditions_for_target", target, expandGroup), &result)
+}
+
+// GetServicesForTarget returns services applicable to a target.
+func (c *WSClient) GetServicesForTarget(ctx context.Context, target TargetSelector, expandGroup bool) ([]ServiceTargetInfo, error) {
+	var result []ServiceTargetInfo
+	if target.IsEmpty() {
+		return nil, ErrEmptyTarget
+	}
+	return result, c.Do(ctx, buildTargetRequest("get_services_for_target", target, expandGroup), &result)
+}
+
+// ListEntityRegistryForDisplay returns a lightweight entity registry dump
+// optimised for UI display (short field names, disabled entities excluded).
+func (c *WSClient) ListEntityRegistryForDisplay(ctx context.Context) (DisplayEntityRegistry, error) {
+	result := DisplayEntityRegistry{}
+	return result, c.Do(ctx, map[string]interface{}{
+		"type": "config/entity_registry/list_for_display",
+	}, &result)
+}
+
+// ListExposedEntities returns the voice-assistant exposure map for every entity
+// (homeassistant/expose_entity/list).
+func (c *WSClient) ListExposedEntities(ctx context.Context) (ExposedEntitiesResult, error) {
+	result := ExposedEntitiesResult{}
+	return result, c.Do(ctx, map[string]interface{}{
+		"type": "homeassistant/expose_entity/list",
+	}, &result)
+}
+
+// ExposeEntity sets voice-assistant exposure for one or more entities.
+// assistants must contain at least one of "conversation", "cloud.alexa",
+// "cloud.google_assistant"; entityIDs must be non-empty.
+func (c *WSClient) ExposeEntity(ctx context.Context, req ExposeEntityRequest) error {
+	if len(req.EntityIDs) == 0 {
+		return ErrEmptyEntityID
+	}
+	return c.Do(ctx, map[string]interface{}{
+		"type":          "homeassistant/expose_entity",
+		"assistants":    req.Assistants,
+		"entity_ids":    req.EntityIDs,
+		"should_expose": req.ShouldExpose,
+	}, nil)
+}
+
+func buildTargetRequest(commandType string, target TargetSelector, expandGroup bool) map[string]interface{} {
+	return map[string]interface{}{
+		"type":         commandType,
+		"target":       target,
+		"expand_group": expandGroup,
+	}
 }
 
 func (c *WSClient) Do(ctx context.Context, req map[string]interface{}, out interface{}) error {

--- a/ws_client_test.go
+++ b/ws_client_test.go
@@ -1304,7 +1304,12 @@ func TestWSClient_DeclareSupportedFeatures(t *testing.T) {
 				return nil, false
 			}
 			features, ok := req["features"].(map[string]interface{})
-			if !ok || features["coalesce_messages"].(float64) != 1 {
+			if !ok {
+				reportHandlerErr(errCh, errors.New("expected features object"))
+				return nil, false
+			}
+			val, ok := features["coalesce_messages"].(float64)
+			if !ok || val != 1 {
 				reportHandlerErr(errCh, errors.New("expected coalesce_messages=1"))
 				return nil, false
 			}
@@ -1893,6 +1898,7 @@ func TestDecodeIncomingFrame_Strict(t *testing.T) {
 		{"string literal rejected", `"oops"`, 0, false},
 		{"empty frame rejected", ``, 0, false},
 		{"whitespace-only rejected", "   \n", 0, false},
+		{"empty array rejected", `[]`, 0, false},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/ws_client_test.go
+++ b/ws_client_test.go
@@ -1817,6 +1817,18 @@ func TestWSClient_ExposeEntity_EmptyEntityIDs(t *testing.T) {
 	}
 }
 
+func TestWSClient_ExposeEntity_EmptyAssistants(t *testing.T) {
+	t.Parallel()
+
+	ws := NewWSClient(ClientConfig{Host: "http://localhost:8123", Token: "token"})
+	err := ws.ExposeEntity(context.Background(), ExposeEntityRequest{
+		EntityIDs: []string{"light.kitchen"},
+	})
+	if !errors.Is(err, ErrEmptyAssistants) {
+		t.Fatalf("expected ErrEmptyAssistants, got: %v", err)
+	}
+}
+
 // TestWSClient_Do_StillWorks_ForNewCommands verifies raw Do() continues to work
 // for the same commands that now have typed wrappers (backwards compatibility).
 func TestWSClient_Do_StillWorks_ForNewCommands(t *testing.T) {

--- a/ws_client_test.go
+++ b/ws_client_test.go
@@ -1876,6 +1876,85 @@ func TestWSClient_Do_StillWorks_ForNewCommands(t *testing.T) {
 	assertNoHandlerErr(t, errCh)
 }
 
+func TestDecodeIncomingFrame_Strict(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		input  string
+		count  int
+		wantOK bool
+	}{
+		{"object", `{"type":"result","id":1,"success":true}`, 1, true},
+		{"array", `[{"type":"event","id":1},{"type":"pong","id":2}]`, 2, true},
+		{"leading whitespace then object", "  \n\t{\"type\":\"pong\"}", 1, true},
+		{"null literal rejected", `null`, 0, false},
+		{"number literal rejected", `42`, 0, false},
+		{"string literal rejected", `"oops"`, 0, false},
+		{"empty frame rejected", ``, 0, false},
+		{"whitespace-only rejected", "   \n", 0, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			msgs, err := decodeIncomingFrame([]byte(tc.input))
+			if tc.wantOK {
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				if len(msgs) != tc.count {
+					t.Fatalf("count: got %d want %d", len(msgs), tc.count)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error, got msgs=%v", msgs)
+			}
+		})
+	}
+}
+
+// TestWSClient_NonTextFrame_FailsPending verifies that a binary frame is
+// treated as a protocol violation (HA only sends text frames).
+func TestWSClient_NonTextFrame_FailsPending(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		defer conn.Close()
+
+		_ = conn.WriteJSON(map[string]interface{}{"type": "auth_required"})
+		_ = conn.ReadJSON(&map[string]interface{}{})
+		_ = conn.WriteJSON(map[string]interface{}{"type": "auth_ok"})
+
+		req := map[string]interface{}{}
+		if err := conn.ReadJSON(&req); err != nil {
+			reportHandlerErr(errCh, err)
+			return
+		}
+		_ = conn.WriteMessage(websocket.BinaryMessage, []byte("\x00\x01\x02"))
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := ws.Do(ctx, map[string]interface{}{"type": "get_panels"}, nil)
+	if err == nil {
+		t.Fatalf("expected error from pending Do, got nil")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Do should not block on binary frame: %v", err)
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
 // TestWSClient_MalformedFrame_FailsPending verifies that a non-JSON frame is
 // treated as a fatal protocol error: pending callers get the decode error
 // rather than blocking until their context expires.

--- a/ws_client_test.go
+++ b/ws_client_test.go
@@ -1552,8 +1552,9 @@ func TestWSClient_ExtractFromTarget(t *testing.T) {
 				"type":    "result",
 				"success": true,
 				"result": map[string]interface{}{
-					"entity_ids": []string{"light.kitchen", "switch.kitchen"},
-					"area_ids":   []string{"kitchen"},
+					"referenced_entities": []string{"light.kitchen", "switch.kitchen"},
+					"referenced_areas":    []string{"kitchen"},
+					"missing_floors":      []string{},
 				},
 			}, true
 		})
@@ -1570,8 +1571,8 @@ func TestWSClient_ExtractFromTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("extract: %v", err)
 	}
-	if len(res.EntityIDs) != 2 || res.EntityIDs[0] != "light.kitchen" {
-		t.Fatalf("unexpected entities: %#v", res.EntityIDs)
+	if len(res.ReferencedEntities) != 2 || res.ReferencedEntities[0] != "light.kitchen" {
+		t.Fatalf("unexpected entities: %#v", res.ReferencedEntities)
 	}
 	assertNoHandlerErr(t, errCh)
 }
@@ -1591,34 +1592,31 @@ func TestWSClient_TargetHelpers(t *testing.T) {
 	tests := []struct {
 		name        string
 		expectType  string
-		call        func(ws *WSClient) error
+		call        func(ws *WSClient) ([]string, error)
 		expandGroup bool
 	}{
 		{
 			name:        "triggers",
 			expectType:  "get_triggers_for_target",
 			expandGroup: true,
-			call: func(ws *WSClient) error {
-				_, err := ws.GetTriggersForTarget(context.Background(), TargetSelector{EntityID: []string{"light.kitchen"}}, true)
-				return err
+			call: func(ws *WSClient) ([]string, error) {
+				return ws.GetTriggersForTarget(context.Background(), TargetSelector{EntityID: []string{"light.kitchen"}}, true)
 			},
 		},
 		{
 			name:        "conditions",
 			expectType:  "get_conditions_for_target",
 			expandGroup: true,
-			call: func(ws *WSClient) error {
-				_, err := ws.GetConditionsForTarget(context.Background(), TargetSelector{EntityID: []string{"light.kitchen"}}, true)
-				return err
+			call: func(ws *WSClient) ([]string, error) {
+				return ws.GetConditionsForTarget(context.Background(), TargetSelector{EntityID: []string{"light.kitchen"}}, true)
 			},
 		},
 		{
 			name:        "services",
 			expectType:  "get_services_for_target",
 			expandGroup: false,
-			call: func(ws *WSClient) error {
-				_, err := ws.GetServicesForTarget(context.Background(), TargetSelector{EntityID: []string{"light.kitchen"}}, false)
-				return err
+			call: func(ws *WSClient) ([]string, error) {
+				return ws.GetServicesForTarget(context.Background(), TargetSelector{EntityID: []string{"light.kitchen"}}, false)
 			},
 		},
 	}
@@ -1642,7 +1640,7 @@ func TestWSClient_TargetHelpers(t *testing.T) {
 					return map[string]interface{}{
 						"type":    "result",
 						"success": true,
-						"result":  []map[string]interface{}{{"platform": "state"}},
+						"result":  []string{"light.turned_on", "light.turned_off"},
 					}, true
 				})
 			})
@@ -1654,8 +1652,12 @@ func TestWSClient_TargetHelpers(t *testing.T) {
 			}
 			t.Cleanup(func() { _ = ws.Close() })
 
-			if err := tc.call(ws); err != nil {
+			res, err := tc.call(ws)
+			if err != nil {
 				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if len(res) != 2 || res[0] != "light.turned_on" {
+				t.Fatalf("%s: unexpected result %#v", tc.name, res)
 			}
 			assertNoHandlerErr(t, errCh)
 		})
@@ -1691,8 +1693,13 @@ func TestWSClient_ListEntityRegistryForDisplay(t *testing.T) {
 				"type":    "result",
 				"success": true,
 				"result": map[string]interface{}{
+					"entity_categories": map[string]interface{}{
+						"0": "config",
+						"1": "diagnostic",
+					},
 					"entities": []map[string]interface{}{
 						{"ei": "light.kitchen", "dn": "Kitchen"},
+						{"ei": "sensor.battery", "dn": "Battery", "ec": float64(1)},
 					},
 				},
 			}, true
@@ -1710,8 +1717,11 @@ func TestWSClient_ListEntityRegistryForDisplay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list for display: %v", err)
 	}
-	if len(res.Entities) != 1 || res.Entities[0]["ei"] != "light.kitchen" {
+	if len(res.Entities) != 2 || res.Entities[0]["ei"] != "light.kitchen" {
 		t.Fatalf("unexpected entities: %#v", res.Entities)
+	}
+	if res.EntityCategories["1"] != "diagnostic" {
+		t.Fatalf("unexpected entity_categories: %#v", res.EntityCategories)
 	}
 	assertNoHandlerErr(t, errCh)
 }
@@ -1862,6 +1872,124 @@ func TestWSClient_Do_StillWorks_ForNewCommands(t *testing.T) {
 	}
 	if _, ok := raw["lovelace"]; !ok {
 		t.Fatalf("expected lovelace key in raw response: %#v", raw)
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
+// TestWSClient_MalformedFrame_FailsPending verifies that a non-JSON frame is
+// treated as a fatal protocol error: pending callers get the decode error
+// rather than blocking until their context expires.
+func TestWSClient_MalformedFrame_FailsPending(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		defer conn.Close()
+
+		_ = conn.WriteJSON(map[string]interface{}{"type": "auth_required"})
+		_ = conn.ReadJSON(&map[string]interface{}{})
+		_ = conn.WriteJSON(map[string]interface{}{"type": "auth_ok"})
+
+		req := map[string]interface{}{}
+		if err := conn.ReadJSON(&req); err != nil {
+			reportHandlerErr(errCh, err)
+			return
+		}
+		// Reply with garbage that is neither a JSON object nor array.
+		_ = conn.WriteMessage(websocket.TextMessage, []byte("not-json"))
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := ws.Do(ctx, map[string]interface{}{"type": "get_panels"}, nil)
+	if err == nil {
+		t.Fatalf("expected error from pending Do, got nil")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Do should not block until ctx deadline on malformed frame: %v", err)
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
+// TestWSClient_CoalescedMessages exercises readLoop on a single text frame
+// that contains a JSON array of messages, which is what HA sends after
+// coalesce_messages is enabled via supported_features.
+func TestWSClient_CoalescedMessages(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		defer conn.Close()
+
+		_ = conn.WriteJSON(map[string]interface{}{"type": "auth_required"})
+		_ = conn.ReadJSON(&map[string]interface{}{})
+		_ = conn.WriteJSON(map[string]interface{}{"type": "auth_ok"})
+
+		subReq := map[string]interface{}{}
+		if err := conn.ReadJSON(&subReq); err != nil {
+			reportHandlerErr(errCh, err)
+			return
+		}
+		if subReq["type"] != "subscribe_events" {
+			reportHandlerErr(errCh, errors.New("expected subscribe_events"))
+			return
+		}
+
+		batch := []map[string]interface{}{
+			{"id": subReq["id"], "type": "result", "success": true, "result": nil},
+			{"id": subReq["id"], "type": "event", "event": map[string]interface{}{
+				"event_type": "state_changed",
+				"data":       map[string]interface{}{"entity_id": "light.kitchen"},
+			}},
+			{"id": subReq["id"], "type": "event", "event": map[string]interface{}{
+				"event_type": "state_changed",
+				"data":       map[string]interface{}{"entity_id": "light.living_room"},
+			}},
+		}
+		payload, err := json.Marshal(batch)
+		if err != nil {
+			reportHandlerErr(errCh, err)
+			return
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, payload); err != nil {
+			reportHandlerErr(errCh, err)
+			return
+		}
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	sub, err := ws.SubscribeEvents(context.Background(), "state_changed")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	seen := make([]string, 0, 2)
+	for len(seen) < 2 {
+		select {
+		case ev := <-sub.Events():
+			if ev.EventType != "state_changed" {
+				t.Fatalf("unexpected event type: %s", ev.EventType)
+			}
+			seen = append(seen, string(ev.Data))
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout: only got %d coalesced events", len(seen))
+		}
+	}
+	if !strings.Contains(seen[0], "light.kitchen") || !strings.Contains(seen[1], "light.living_room") {
+		t.Fatalf("unexpected coalesced events: %v", seen)
 	}
 	assertNoHandlerErr(t, errCh)
 }

--- a/ws_client_test.go
+++ b/ws_client_test.go
@@ -1265,3 +1265,591 @@ func newWSTestServer(t *testing.T, errCh chan error, fn func(conn *websocket.Con
 	}))
 	return server
 }
+
+// handshakeAndServe performs the auth_required/auth/auth_ok handshake and then
+// delegates to the per-test handler. It is a small helper to keep new command
+// tests concise.
+func handshakeAndServe(errCh chan error, conn *websocket.Conn, handle func(req map[string]interface{}) (response map[string]interface{}, ok bool)) {
+	defer conn.Close()
+	_ = conn.WriteJSON(map[string]interface{}{"type": "auth_required"})
+	_ = conn.ReadJSON(&map[string]interface{}{})
+	_ = conn.WriteJSON(map[string]interface{}{"type": "auth_ok"})
+
+	req := map[string]interface{}{}
+	if err := conn.ReadJSON(&req); err != nil {
+		reportHandlerErr(errCh, err)
+		return
+	}
+	resp, ok := handle(req)
+	if !ok {
+		return
+	}
+	if resp == nil {
+		resp = map[string]interface{}{"type": "result", "success": true}
+	}
+	if _, has := resp["id"]; !has {
+		resp["id"] = req["id"]
+	}
+	_ = conn.WriteJSON(resp)
+}
+
+func TestWSClient_DeclareSupportedFeatures(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		handshakeAndServe(errCh, conn, func(req map[string]interface{}) (map[string]interface{}, bool) {
+			if req["type"] != "supported_features" {
+				reportHandlerErr(errCh, errors.New("expected supported_features"))
+				return nil, false
+			}
+			features, ok := req["features"].(map[string]interface{})
+			if !ok || features["coalesce_messages"].(float64) != 1 {
+				reportHandlerErr(errCh, errors.New("expected coalesce_messages=1"))
+				return nil, false
+			}
+			return nil, true
+		})
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	if err := ws.DeclareSupportedFeatures(context.Background(), map[string]interface{}{
+		"coalesce_messages": 1,
+	}); err != nil {
+		t.Fatalf("declare supported features: %v", err)
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
+// TestWSClient_Connect_NoAutoSupportedFeatures verifies Connect does not
+// automatically send supported_features (backwards compatibility).
+func TestWSClient_Connect_NoAutoSupportedFeatures(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		defer conn.Close()
+		_ = conn.WriteJSON(map[string]interface{}{"type": "auth_required"})
+		_ = conn.ReadJSON(&map[string]interface{}{})
+		_ = conn.WriteJSON(map[string]interface{}{"type": "auth_ok"})
+
+		// Expect the next message to be ping, not supported_features.
+		msg := map[string]interface{}{}
+		if err := conn.ReadJSON(&msg); err != nil {
+			reportHandlerErr(errCh, err)
+			return
+		}
+		if msg["type"] == "supported_features" {
+			reportHandlerErr(errCh, errors.New("Connect must not send supported_features automatically"))
+			return
+		}
+		if msg["type"] != "ping" {
+			reportHandlerErr(errCh, errors.New("expected ping as first post-auth message"))
+			return
+		}
+		_ = conn.WriteJSON(map[string]interface{}{"type": "pong", "id": msg["id"]})
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	if err := ws.Ping(context.Background()); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
+func TestWSClient_GetPanels(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		handshakeAndServe(errCh, conn, func(req map[string]interface{}) (map[string]interface{}, bool) {
+			if req["type"] != "get_panels" {
+				reportHandlerErr(errCh, errors.New("expected get_panels"))
+				return nil, false
+			}
+			return map[string]interface{}{
+				"type":    "result",
+				"success": true,
+				"result": map[string]interface{}{
+					"lovelace": map[string]interface{}{
+						"component_name": "lovelace",
+						"url_path":       "lovelace",
+						"require_admin":  false,
+					},
+					"config": map[string]interface{}{
+						"component_name": "config",
+						"url_path":       "config",
+						"icon":           "mdi:cog",
+						"require_admin":  true,
+					},
+				},
+			}, true
+		})
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	panels, err := ws.GetPanels(context.Background())
+	if err != nil {
+		t.Fatalf("get panels: %v", err)
+	}
+	if len(panels) != 2 {
+		t.Fatalf("expected 2 panels, got %d", len(panels))
+	}
+	if panels["config"].Icon != "mdi:cog" || !panels["config"].RequireAdmin {
+		t.Fatalf("unexpected config panel: %#v", panels["config"])
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
+func TestWSClient_GetPanels_Error(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		handshakeAndServe(errCh, conn, func(req map[string]interface{}) (map[string]interface{}, bool) {
+			return map[string]interface{}{
+				"type":    "result",
+				"success": false,
+				"error":   map[string]interface{}{"code": "unknown_error", "message": "boom"},
+			}, true
+		})
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	_, err := ws.GetPanels(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected ws error, got: %v", err)
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
+func TestWSClient_ValidateConfig_Valid(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		handshakeAndServe(errCh, conn, func(req map[string]interface{}) (map[string]interface{}, bool) {
+			if req["type"] != "validate_config" {
+				reportHandlerErr(errCh, errors.New("expected validate_config"))
+				return nil, false
+			}
+			if _, has := req["trigger"]; !has {
+				reportHandlerErr(errCh, errors.New("missing trigger in request"))
+				return nil, false
+			}
+			return map[string]interface{}{
+				"type":    "result",
+				"success": true,
+				"result": map[string]interface{}{
+					"trigger": map[string]interface{}{"valid": true},
+				},
+			}, true
+		})
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	res, err := ws.ValidateConfig(context.Background(), ValidateConfigRequest{
+		Trigger: map[string]interface{}{"platform": "state", "entity_id": "light.kitchen"},
+	})
+	if err != nil {
+		t.Fatalf("validate config: %v", err)
+	}
+	if res.Trigger == nil || !res.Trigger.Valid {
+		t.Fatalf("expected valid trigger, got %#v", res.Trigger)
+	}
+	if res.Condition != nil || res.Action != nil {
+		t.Fatalf("expected nil condition/action, got %#v", res)
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
+func TestWSClient_ValidateConfig_Invalid(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		handshakeAndServe(errCh, conn, func(req map[string]interface{}) (map[string]interface{}, bool) {
+			return map[string]interface{}{
+				"type":    "result",
+				"success": true,
+				"result": map[string]interface{}{
+					"action": map[string]interface{}{"valid": false, "error": "unknown service foo.bar"},
+				},
+			}, true
+		})
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	res, err := ws.ValidateConfig(context.Background(), ValidateConfigRequest{
+		Action: map[string]interface{}{"service": "foo.bar"},
+	})
+	if err != nil {
+		t.Fatalf("validate config: %v", err)
+	}
+	if res.Action == nil || res.Action.Valid || res.Action.Error == "" {
+		t.Fatalf("expected invalid action, got %#v", res.Action)
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
+func TestWSClient_ExtractFromTarget(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		handshakeAndServe(errCh, conn, func(req map[string]interface{}) (map[string]interface{}, bool) {
+			if req["type"] != "extract_from_target" {
+				reportHandlerErr(errCh, errors.New("expected extract_from_target"))
+				return nil, false
+			}
+			if req["expand_group"] != false {
+				reportHandlerErr(errCh, errors.New("expected expand_group=false"))
+				return nil, false
+			}
+			target, _ := req["target"].(map[string]interface{})
+			areas, _ := target["area_id"].([]interface{})
+			if len(areas) != 1 || areas[0] != "kitchen" {
+				reportHandlerErr(errCh, errors.New("unexpected target payload"))
+				return nil, false
+			}
+			return map[string]interface{}{
+				"type":    "result",
+				"success": true,
+				"result": map[string]interface{}{
+					"entity_ids": []string{"light.kitchen", "switch.kitchen"},
+					"area_ids":   []string{"kitchen"},
+				},
+			}, true
+		})
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	res, err := ws.ExtractFromTarget(context.Background(), TargetSelector{AreaID: []string{"kitchen"}}, false)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(res.EntityIDs) != 2 || res.EntityIDs[0] != "light.kitchen" {
+		t.Fatalf("unexpected entities: %#v", res.EntityIDs)
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
+func TestWSClient_ExtractFromTarget_EmptyTarget(t *testing.T) {
+	t.Parallel()
+
+	ws := NewWSClient(ClientConfig{Host: "http://localhost:8123", Token: "token"})
+	if _, err := ws.ExtractFromTarget(context.Background(), TargetSelector{}, false); !errors.Is(err, ErrEmptyTarget) {
+		t.Fatalf("expected ErrEmptyTarget, got: %v", err)
+	}
+}
+
+func TestWSClient_TargetHelpers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		expectType  string
+		call        func(ws *WSClient) error
+		expandGroup bool
+	}{
+		{
+			name:        "triggers",
+			expectType:  "get_triggers_for_target",
+			expandGroup: true,
+			call: func(ws *WSClient) error {
+				_, err := ws.GetTriggersForTarget(context.Background(), TargetSelector{EntityID: []string{"light.kitchen"}}, true)
+				return err
+			},
+		},
+		{
+			name:        "conditions",
+			expectType:  "get_conditions_for_target",
+			expandGroup: true,
+			call: func(ws *WSClient) error {
+				_, err := ws.GetConditionsForTarget(context.Background(), TargetSelector{EntityID: []string{"light.kitchen"}}, true)
+				return err
+			},
+		},
+		{
+			name:        "services",
+			expectType:  "get_services_for_target",
+			expandGroup: false,
+			call: func(ws *WSClient) error {
+				_, err := ws.GetServicesForTarget(context.Background(), TargetSelector{EntityID: []string{"light.kitchen"}}, false)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			errCh := make(chan error, 1)
+			srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+				handshakeAndServe(errCh, conn, func(req map[string]interface{}) (map[string]interface{}, bool) {
+					if req["type"] != tc.expectType {
+						reportHandlerErr(errCh, errors.New("unexpected type: "+req["type"].(string)))
+						return nil, false
+					}
+					if req["expand_group"] != tc.expandGroup {
+						reportHandlerErr(errCh, errors.New("unexpected expand_group"))
+						return nil, false
+					}
+					return map[string]interface{}{
+						"type":    "result",
+						"success": true,
+						"result":  []map[string]interface{}{{"platform": "state"}},
+					}, true
+				})
+			})
+			defer srv.Close()
+
+			ws := newTestWSClient(t, srv.URL, "test-token")
+			if err := ws.Connect(context.Background()); err != nil {
+				t.Fatalf("connect: %v", err)
+			}
+			t.Cleanup(func() { _ = ws.Close() })
+
+			if err := tc.call(ws); err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			assertNoHandlerErr(t, errCh)
+		})
+	}
+}
+
+func TestWSClient_TargetHelpers_EmptyTarget(t *testing.T) {
+	t.Parallel()
+
+	ws := NewWSClient(ClientConfig{Host: "http://localhost:8123", Token: "token"})
+	if _, err := ws.GetTriggersForTarget(context.Background(), TargetSelector{}, true); !errors.Is(err, ErrEmptyTarget) {
+		t.Fatalf("triggers: expected ErrEmptyTarget, got: %v", err)
+	}
+	if _, err := ws.GetConditionsForTarget(context.Background(), TargetSelector{}, true); !errors.Is(err, ErrEmptyTarget) {
+		t.Fatalf("conditions: expected ErrEmptyTarget, got: %v", err)
+	}
+	if _, err := ws.GetServicesForTarget(context.Background(), TargetSelector{}, true); !errors.Is(err, ErrEmptyTarget) {
+		t.Fatalf("services: expected ErrEmptyTarget, got: %v", err)
+	}
+}
+
+func TestWSClient_ListEntityRegistryForDisplay(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		handshakeAndServe(errCh, conn, func(req map[string]interface{}) (map[string]interface{}, bool) {
+			if req["type"] != "config/entity_registry/list_for_display" {
+				reportHandlerErr(errCh, errors.New("expected config/entity_registry/list_for_display, got: "+req["type"].(string)))
+				return nil, false
+			}
+			return map[string]interface{}{
+				"type":    "result",
+				"success": true,
+				"result": map[string]interface{}{
+					"entities": []map[string]interface{}{
+						{"ei": "light.kitchen", "dn": "Kitchen"},
+					},
+				},
+			}, true
+		})
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	res, err := ws.ListEntityRegistryForDisplay(context.Background())
+	if err != nil {
+		t.Fatalf("list for display: %v", err)
+	}
+	if len(res.Entities) != 1 || res.Entities[0]["ei"] != "light.kitchen" {
+		t.Fatalf("unexpected entities: %#v", res.Entities)
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
+func TestWSClient_ListExposedEntities(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		handshakeAndServe(errCh, conn, func(req map[string]interface{}) (map[string]interface{}, bool) {
+			if req["type"] != "homeassistant/expose_entity/list" {
+				reportHandlerErr(errCh, errors.New("expected expose_entity/list"))
+				return nil, false
+			}
+			return map[string]interface{}{
+				"type":    "result",
+				"success": true,
+				"result": map[string]interface{}{
+					"exposed_entities": map[string]interface{}{
+						"light.kitchen": map[string]interface{}{
+							"conversation": true,
+							"cloud.alexa":  false,
+						},
+					},
+				},
+			}, true
+		})
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	res, err := ws.ListExposedEntities(context.Background())
+	if err != nil {
+		t.Fatalf("list exposed: %v", err)
+	}
+	exposure := res.ExposedEntities["light.kitchen"]
+	if !exposure["conversation"] || exposure["cloud.alexa"] {
+		t.Fatalf("unexpected exposure: %#v", exposure)
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
+func TestWSClient_ExposeEntity(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		handshakeAndServe(errCh, conn, func(req map[string]interface{}) (map[string]interface{}, bool) {
+			if req["type"] != "homeassistant/expose_entity" {
+				reportHandlerErr(errCh, errors.New("expected expose_entity"))
+				return nil, false
+			}
+			ids, _ := req["entity_ids"].([]interface{})
+			assistants, _ := req["assistants"].([]interface{})
+			if len(ids) != 1 || ids[0] != "light.kitchen" {
+				reportHandlerErr(errCh, errors.New("unexpected entity_ids"))
+				return nil, false
+			}
+			if len(assistants) != 1 || assistants[0] != "conversation" {
+				reportHandlerErr(errCh, errors.New("unexpected assistants"))
+				return nil, false
+			}
+			if req["should_expose"] != true {
+				reportHandlerErr(errCh, errors.New("expected should_expose=true"))
+				return nil, false
+			}
+			return nil, true
+		})
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	err := ws.ExposeEntity(context.Background(), ExposeEntityRequest{
+		Assistants:   []string{"conversation"},
+		EntityIDs:    []string{"light.kitchen"},
+		ShouldExpose: true,
+	})
+	if err != nil {
+		t.Fatalf("expose entity: %v", err)
+	}
+	assertNoHandlerErr(t, errCh)
+}
+
+func TestWSClient_ExposeEntity_EmptyEntityIDs(t *testing.T) {
+	t.Parallel()
+
+	ws := NewWSClient(ClientConfig{Host: "http://localhost:8123", Token: "token"})
+	err := ws.ExposeEntity(context.Background(), ExposeEntityRequest{
+		Assistants: []string{"conversation"},
+	})
+	if !errors.Is(err, ErrEmptyEntityID) {
+		t.Fatalf("expected ErrEmptyEntityID, got: %v", err)
+	}
+}
+
+// TestWSClient_Do_StillWorks_ForNewCommands verifies raw Do() continues to work
+// for the same commands that now have typed wrappers (backwards compatibility).
+func TestWSClient_Do_StillWorks_ForNewCommands(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := newWSTestServer(t, errCh, func(conn *websocket.Conn) {
+		handshakeAndServe(errCh, conn, func(req map[string]interface{}) (map[string]interface{}, bool) {
+			if req["type"] != "get_panels" {
+				reportHandlerErr(errCh, errors.New("expected get_panels"))
+				return nil, false
+			}
+			return map[string]interface{}{
+				"type":    "result",
+				"success": true,
+				"result":  map[string]interface{}{"lovelace": map[string]interface{}{"component_name": "lovelace", "url_path": "lovelace"}},
+			}, true
+		})
+	})
+	defer srv.Close()
+
+	ws := newTestWSClient(t, srv.URL, "test-token")
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	raw := map[string]json.RawMessage{}
+	if err := ws.Do(context.Background(), map[string]interface{}{"type": "get_panels"}, &raw); err != nil {
+		t.Fatalf("raw do: %v", err)
+	}
+	if _, ok := raw["lovelace"]; !ok {
+		t.Fatalf("expected lovelace key in raw response: %#v", raw)
+	}
+	assertNoHandlerErr(t, errCh)
+}


### PR DESCRIPTION
## What changed

Audits this client against the current official Home Assistant documentation and closes the gap on the WebSocket side.

- **REST API**: confirmed 100% coverage against https://developers.home-assistant.io/docs/api/rest — nothing deprecated, nothing missing. No REST changes.
- **WebSocket API**: added typed helpers for the 10 documented commands that previously had no Go wrapper. Callers could already send them via the generic `WSClient.Do(...)`, but there were no typed requests/responses or input validation.

### New `WSClient` methods

| WS command | Method |
|---|---|
| `supported_features` | `DeclareSupportedFeatures` (opt-in; never sent automatically) |
| `get_panels` | `GetPanels` |
| `validate_config` | `ValidateConfig` |
| `extract_from_target` | `ExtractFromTarget` |
| `get_triggers_for_target` | `GetTriggersForTarget` |
| `get_conditions_for_target` | `GetConditionsForTarget` |
| `get_services_for_target` | `GetServicesForTarget` |
| `config/entity_registry/list_for_display` | `ListEntityRegistryForDisplay` |
| `homeassistant/expose_entity/list` | `ListExposedEntities` |
| `homeassistant/expose_entity` | `ExposeEntity` |

### New public types (`types.go`)

`Panel`, `Panels`, `TargetSelector`, `ValidateConfigRequest`, `ValidateConfigSectionResult`, `ValidateConfigResult`, `ExtractFromTargetResult`, `DisplayEntity`, `DisplayEntityRegistry`, `ExposedEntitiesResult`, `ExposeEntityRequest`.

Note: `get_triggers_for_target`, `get_conditions_for_target`, and `get_services_for_target` return slices of `"domain.name"` identifier strings per the official docs (not structured objects), so no dedicated `TriggerInfo`/`ConditionInfo`/`ServiceTargetInfo` types are needed.

### New sentinel errors

- `ErrEmptyTarget` — returned by the target helpers when the `TargetSelector` has no references.
- `ErrEmptyAssistants` — returned by `ExposeEntity` when called without at least one target assistant.

### New runnable examples

- `examples/ws_panels`
- `examples/ws_validate_config`
- `examples/ws_entity_registry`
- `examples/ws_expose_entity`
- `examples/ws_target_helpers`
- `examples/ws_supported_features`

### Documentation

- `README.md` — new table mapping every documented WebSocket command to its Go helper, plus a note that any future or undocumented command can still be sent through `WSClient.Do(...)`.
- `CHANGELOG.md`, `RELEASE_NOTES.md`, `MIGRATION.md`, `examples/README.md` — updated with the v2.2.0 entry.

## Why

The client already targeted the official Home Assistant REST + WebSocket docs, but the WebSocket side had drifted: 10 documented commands were reachable only through the generic `WSClient.Do(...)` escape hatch, with no typed requests, no typed responses, and no input validation. This PR brings parity with the official docs so that every documented command has a first-class Go API, while keeping the raw `Do(...)` path available for anything not (yet) documented.

## Backwards compatibility

**Purely additive.** No migration required from v2.1.x to v2.2.0.

- No existing method signature changes.
- No existing type changes.
- `Connect()` handshake sequence is unchanged — `supported_features` is **only** sent when the caller explicitly invokes `DeclareSupportedFeatures`.
- `WSClient.Do(ctx, req, out)` keeps working for every command, including the ones that now have typed wrappers.
- No `go.mod` changes from this PR; still `gorilla/websocket v1.5.3`. Minimum Go is `1.25.10` per the latest main.

## Checklist

- [x] I ran `go build ./... && go vet ./... && go test ./... -race -count=1` locally.
- [x] I added/updated tests for behavior changes (14+ new tests, including regression tests `TestWSClient_Connect_NoAutoSupportedFeatures` and `TestWSClient_Do_StillWorks_ForNewCommands`).
- [x] I updated `README.md` for public API changes (new table mapping every WS command to its Go helper).
- [x] I updated `CHANGELOG.md` (new v2.2.0 entry; also updated `RELEASE_NOTES.md` and `MIGRATION.md`).
