### PR TITLE
chore: bump Go toolchain to 1.25.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: make tools
       - run: make ci
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: |
           cp go.mod /tmp/go.mod
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -race ./...
 
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./...
       - uses: actions/upload-artifact@v4
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: "$(go env GOPATH)/bin/govulncheck ./..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version-file: go.mod
           cache: true
       - run: make tools
       - run: make ci
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version-file: go.mod
           cache: true
       - run: |
           cp go.mod /tmp/go.mod
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version-file: go.mod
           cache: true
       - run: go test -race ./...
 
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version-file: go.mod
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./...
       - uses: actions/upload-artifact@v4
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.10"
+          go-version-file: go.mod
           cache: true
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: "$(go env GOPATH)/bin/govulncheck ./..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [v2.1.2]
+
+### Changed
+- Bump minimum Go version, toolchain, and CI from `1.25.9` to `1.25.10`.
+
+### Fixed
+- Address standard library vulnerability findings from `govulncheck` by running on Go `1.25.10` (fixes include GO-2026-4971 (`net`) and GO-2026-4918 (`net/http`)).
+
 ## [v2.1.1]
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for contributing to `go-ha-client`!
 ## Development setup
 
 Requirements:
-- Go `1.25.9+`
+- Go `1.25.10+`
 - Make
 
 Clone and run checks:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://developers.home-assistant.io/docs/api/websocket
 The client follows official Home Assistant REST and WebSocket API docs.
 
 ### Requirements
-- Go `1.25.9+`
+- Go `1.25.10+`
 - Home Assistant with long-lived access token
 
 ### Get a Home Assistant token
@@ -35,7 +35,7 @@ The client follows official Home Assistant REST and WebSocket API docs.
 - `v2.x` releases may add new helpers/options and bug fixes, but will not introduce intentional breaking API changes.
 - Breaking API changes will be introduced only in a new major version (for example `v3`).
 - The package targets official Home Assistant REST and WebSocket APIs and follows their documented behavior where possible.
-- Minimum supported Go version is `1.25.9+` (see CI/tooling in this repository).
+- Minimum supported Go version is `1.25.10+` (see CI/tooling in this repository).
 - Security issues should be reported using the process in [`SECURITY.md`](SECURITY.md).
 
 ### Non-goals

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,28 @@
 # Release Notes
 
+## v2.1.2
+
+Security and tooling maintenance release for `v2`.
+
+### Highlights
+- Bump minimum Go version, module toolchain, and CI runtime from `1.25.9` to `1.25.10`.
+- Resolve reachable `govulncheck` findings from the Go standard library by running/building with patched Go release:
+  - GO-2026-4971 (`net`)
+  - GO-2026-4918 (`net/http`)
+
+### Compatibility
+- No public API changes.
+- No import path changes (`github.com/mkelcik/go-ha-client/v2`).
+- Existing `v2.x` integrations should continue to work without code changes.
+
+### Upgrade Notes
+- Ensure local/dev/CI environments use Go `1.25.10+`.
+- If your pipeline pins Go patch versions, update them to `1.25.10` or newer.
+
+### Verification Summary
+- `go test ./...` passes.
+- `govulncheck ./...` reports no reachable vulnerabilities on Go `1.25.10`.
+
 ## v2.1.1
 
 Security and tooling maintenance release for `v2`.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/mkelcik/go-ha-client/v2
 
 go 1.25
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## Summary
- Bump Go toolchain and CI from `1.25.9` to `1.25.10`.
- Fixes the failing nightly `vuln_nightly` job by addressing reachable `govulncheck` findings from the Go standard library:
  - `GO-2026-4971` (`net`) — Panic in `Dial`/`LookupPort` on Windows with NUL byte. Reached via `WSClient.connectLocked` → `websocket.Dialer.DialContext` → `net.Dialer.DialContext`.
  - `GO-2026-4918` (`net/http`) — Infinite loop in HTTP/2 transport on bad `SETTINGS_MAX_FRAME_SIZE`. Reached via `Client.doWithHeaders` → `http.Client.Do`.
- Updates `CHANGELOG.md`, `RELEASE_NOTES.md`, `CONTRIBUTING.md`, and `README.md` to match the prior bump pattern.

## Test plan
- [x] `go test ./...` passes locally.
- [x] `govulncheck ./...` reports no reachable vulnerabilities locally.
- [ ] CI green (ci, mod_tidy_check, race, coverage).
- [ ] Next scheduled `vuln_nightly` run passes.