### PR TITLE
docs: explain security-first rationale for minimum Go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The client follows official Home Assistant REST and WebSocket API docs.
 - Go `1.25.10+`
 - Home Assistant with long-lived access token
 
-The minimum Go version is a deliberate security-first choice: this project tracks the latest patched, supported Go release. Older patch versions of the same minor line may carry unfixed CVEs in `net`, `net/http`, or the TLS stack — all of which this client uses on every request. The minimum is bumped as soon as upstream Go ships a security patch, not on a fixed cadence, and CI runs `govulncheck` to keep this honest. See [`SECURITY.md`](SECURITY.md) for the reporting process.
+The minimum Go version is a deliberate security-first choice: this project tracks the **oldest still-supported Go minor line**, and within that line always its **latest security patch**. Upstream Go officially supports the two most recent minor releases — anything below that no longer receives security fixes, so we won't drop under it. At the same time, older patch versions of the same minor line may carry unfixed CVEs in `net`, `net/http`, or the TLS stack — all of which this client uses on every request — so the patch component is bumped as soon as upstream ships a security release, not on a fixed cadence. CI runs `govulncheck` to keep this honest. See [`SECURITY.md`](SECURITY.md) for the reporting process.
 
 ### Get a Home Assistant token
 1. Open Home Assistant in the browser.
@@ -37,7 +37,7 @@ The minimum Go version is a deliberate security-first choice: this project track
 - `v2.x` releases may add new helpers/options and bug fixes, but will not introduce intentional breaking API changes.
 - Breaking API changes will be introduced only in a new major version (for example `v3`).
 - The package targets official Home Assistant REST and WebSocket APIs and follows their documented behavior where possible.
-- Minimum supported Go version is `1.25.10+` (see CI/tooling in this repository). The minimum tracks the latest patched, supported Go release — bumps are security-driven, not cosmetic, and may land in patch releases (see Requirements above).
+- Minimum supported Go version is `1.25.10+` (see CI/tooling in this repository). The minimum tracks the oldest still-supported Go minor line at its latest security patch — bumps are security-driven, not cosmetic, and may land in patch releases (see Requirements above).
 - Security issues should be reported using the process in [`SECURITY.md`](SECURITY.md).
 
 ### Non-goals

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The client follows official Home Assistant REST and WebSocket API docs.
 - Go `1.25.10+`
 - Home Assistant with long-lived access token
 
+The minimum Go version is a deliberate security-first choice: this project tracks the latest patched, supported Go release. Older patch versions of the same minor line may carry unfixed CVEs in `net`, `net/http`, or the TLS stack — all of which this client uses on every request. The minimum is bumped as soon as upstream Go ships a security patch, not on a fixed cadence, and CI runs `govulncheck` to keep this honest. See [`SECURITY.md`](SECURITY.md) for the reporting process.
+
 ### Get a Home Assistant token
 1. Open Home Assistant in the browser.
 2. Click your user profile (bottom-left).
@@ -35,7 +37,7 @@ The client follows official Home Assistant REST and WebSocket API docs.
 - `v2.x` releases may add new helpers/options and bug fixes, but will not introduce intentional breaking API changes.
 - Breaking API changes will be introduced only in a new major version (for example `v3`).
 - The package targets official Home Assistant REST and WebSocket APIs and follows their documented behavior where possible.
-- Minimum supported Go version is `1.25.10+` (see CI/tooling in this repository).
+- Minimum supported Go version is `1.25.10+` (see CI/tooling in this repository). The minimum tracks the latest patched, supported Go release — bumps are security-driven, not cosmetic, and may land in patch releases (see Requirements above).
 - Security issues should be reported using the process in [`SECURITY.md`](SECURITY.md).
 
 ### Non-goals


### PR DESCRIPTION
## Summary
- Expand the `### Requirements` section in `README.md` to explain that the minimum Go version (`1.25.10+`) is a deliberate security-first decision, not an oversight.
- Clarify that the minimum tracks the **oldest still-supported Go minor line** (upstream Go only supports the two most recent minor releases) and, within that line, its **latest security patch**.
- Note that CI runs `govulncheck` to keep this honest, and that patch-level Go bumps may land in patch releases of this library.
- Add a matching one-liner to `### Stability and Support Policy (v2)` so both sections tell the same story.

## Motivation
A high minimum Go version can look like a weakness on first glance ("why don't they support older Go?"). The new wording reframes it as a security policy: we won't drop below the oldest supported minor line, and we won't sit on unpatched releases of it. Users on a newer Go are unaffected — `1.25.10+` means `+`.

## Test plan
- [ ] Verify `README.md` renders cleanly on GitHub.
- [ ] Check that the rationale paragraph appears under `### Requirements` and the matching one-liner under `### Stability and Support Policy (v2)`.
- [ ] Confirm the PR is documentation-only (no code, `go.mod`, or CI changes).