### PR TITLE
chore: bump Go toolchain to 1.25.12 (fixes GO-2026-5856)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/mkelcik/go-ha-client/v2
 
 go 1.25
 
-toolchain go1.25.10
+toolchain go1.25.12
 
 require github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## Prečo

Nočný job \`vuln_nightly\` (govulncheck) začal padať 9. 7. 2026 s exit code 3:

\`\`\`
Vulnerability #1: GO-2026-5856
  Found in: crypto/tls@go1.25.11
  Fixed in: crypto/tls@go1.25.12
  Your code is affected by 1 vulnerability from the Go standard library.
\`\`\`

Zraniteľnosť je v štandardnej knižnici Go (\`crypto/tls\`), nie v kóde projektu ani v závislostiach. Opravená je v Go 1.25.12.

## Zmena

Bump \`toolchain\` direktívy v \`go.mod\`: \`go1.25.10\` → \`go1.25.12\`. Go toolchain switching zabezpečí, že build (a teda analyzovaná stdlib) beží pod 1.25.12, čím sa zásah odstráni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)