### PR TITLE
docs: prepare v2.2.3 release (crypto/tls security bump)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ gotchas that bite when you generate code without reading the full README.
 - Go module: `github.com/mkelcik/go-ha-client/v2` (v2 is the stable line).
 - Two clients in one package: REST `*Client` and WebSocket `*WSClient`.
 - Import alias used throughout examples and docs: `ha`.
-- Requires Go `1.25.10+` and a Home Assistant long-lived access token.
+- Requires Go `1.25.12+` and a Home Assistant long-lived access token.
 - Never invent entity IDs — they must come from the user's HA instance
   (`Developer Tools -> States`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [v2.2.3] - 2026-07-11
+
+### Security
+- Bump Go toolchain `go1.25.10` → `go1.25.12` to pick up the `crypto/tls` standard-library fix for [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856). The nightly `govulncheck` job flagged it; the vulnerability is in the Go standard library (exercised by every HTTPS/WebSocket request), not in this project's code or dependencies.
+
+### Changed
+- Minimum supported Go version documented as `1.25.12+` across `README.md`, `CONTRIBUTING.md`, and `AGENTS.md`, tracking the latest security patch of the supported Go minor line per the security-first policy.
+
+### Notes
+- No public API changes. Upgrade requires no code changes from `v2.2.2`.
+
 ## [v2.2.2] - 2026-05-29
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for contributing to `go-ha-client`!
 ## Development setup
 
 Requirements:
-- Go `1.25.10+`
+- Go `1.25.12+`
 - Make
 
 Clone and run checks:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://developers.home-assistant.io/docs/api/websocket
 The client follows official Home Assistant REST and WebSocket API docs.
 
 ### Requirements
-- Go `1.25.10+`
+- Go `1.25.12+`
 - Home Assistant with long-lived access token
 
 The minimum Go version is a deliberate security-first choice: this project tracks the **oldest still-supported Go minor line**, and within that line always its **latest security patch**. Upstream Go officially supports the two most recent minor releases — anything below that no longer receives security fixes, so we won't drop under it. At the same time, older patch versions of the same minor line may carry unfixed CVEs in `net`, `net/http`, or the TLS stack — all of which this client uses on every request — so the patch component is bumped as soon as upstream ships a security release, not on a fixed cadence. CI runs `govulncheck` to keep this honest. See [`SECURITY.md`](SECURITY.md) for the reporting process.
@@ -37,7 +37,7 @@ The minimum Go version is a deliberate security-first choice: this project track
 - `v2.x` releases may add new helpers/options and bug fixes, but will not introduce intentional breaking API changes.
 - Breaking API changes will be introduced only in a new major version (for example `v3`).
 - The package targets official Home Assistant REST and WebSocket APIs and follows their documented behavior where possible.
-- Minimum supported Go version is `1.25.10+` (see CI/tooling in this repository). The minimum tracks the oldest still-supported Go minor line at its latest security patch — bumps are security-driven, not cosmetic, and may land in patch releases (see Requirements above).
+- Minimum supported Go version is `1.25.12+` (see CI/tooling in this repository). The minimum tracks the oldest still-supported Go minor line at its latest security patch — bumps are security-driven, not cosmetic, and may land in patch releases (see Requirements above).
 - Security issues should be reported using the process in [`SECURITY.md`](SECURITY.md).
 
 ### Non-goals

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## v2.2.3
+
+Security patch release: bumps the Go toolchain to `go1.25.12` to clear a `crypto/tls` standard-library vulnerability.
+
+### Highlights
+- Toolchain bumped `go1.25.10` → `go1.25.12` in `go.mod`. This picks up the upstream `crypto/tls` fix for [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856), which the nightly `govulncheck` job surfaced.
+- The vulnerability is in the Go standard library (exercised on every HTTPS/WebSocket request), **not** in this project's code or its dependencies.
+- Minimum supported Go version documented as `1.25.12+` in `README.md`, `CONTRIBUTING.md`, and `AGENTS.md`, consistent with the security-first version policy (track the oldest still-supported Go minor line at its latest security patch).
+
+### Compatibility
+- No public API changes.
+- No upgrade steps required from `v2.2.2` beyond building with Go `1.25.12+`.
+
+### Verification Summary
+- Nightly `govulncheck` clears GO-2026-5856 under the bumped toolchain.
+
 ## v2.2.2
 
 Documentation-only release: clarifies the rationale behind the minimum Go version.


### PR DESCRIPTION
Release prep for **v2.2.3**, a security patch release following the Go toolchain bump in #13.

## Changes
- `CHANGELOG.md` + `RELEASE_NOTES.md`: v2.2.3 entry for the `go1.25.10 → go1.25.12` toolchain bump that clears [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) in `crypto/tls`.
- Documented minimum Go version `1.25.10+ → 1.25.12+` across `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, consistent with the security-first version policy.

No public API changes.